### PR TITLE
Flat-field simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ See [`run.sh`](https://github.com/dkazanc/TomoPhantom/blob/master/run.sh) script
 ```
 git clone https://github.com/dkazanc/TomoPhantom.git
 cd TomoPhantom
+export CIL_VERSION=0.10.3
 conda build Wrappers/Python/conda-recipe --numpy 1.12 --python 3.5
 conda install tomophantom --use-local --force
 ```

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ See [`run.sh`](https://github.com/dkazanc/TomoPhantom/blob/master/run.sh) script
 ```
 git clone https://github.com/dkazanc/TomoPhantom.git
 cd TomoPhantom
-export CIL_VERSION=0.10.3
+con
 conda build Wrappers/Python/conda-recipe --numpy 1.12 --python 3.5
 conda install tomophantom --use-local --force
 ```

--- a/Wrappers/Python/Demos/DemoReconASTRA3D_sim.py
+++ b/Wrappers/Python/Demos/DemoReconASTRA3D_sim.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+GPLv3 license (ASTRA toolbox)
+Note that the TomoPhantom package is released under Apache License, Version 2.0
+
+* Script to generate 3D analytical phantoms and their projection data using TomoPhantom
+* Synthetic flat fields are also genererated and noise incorporated into data 
+together with normalisation errors. This simulates more challeneging data for 
+reconstruction.
+* TomoRec is required for reconstruction
+
+>>>>> Dependencies (reconstruction): <<<<<
+1. ASTRA toolbox: conda install -c astra-toolbox astra-toolbox
+2. TomoRec: conda install -c dkazanc tomorec
+or install from https://github.com/dkazanc/TomoRec
+
+@author: Daniil Kazantsev
+"""
+import timeit
+import os
+import matplotlib.pyplot as plt
+import numpy as np
+import tomophantom
+from tomophantom import TomoP3D
+from tomophantom.supp.qualitymetrics import QualityTools
+from tomophantom.supp.flatsgen import flats
+from tomophantom.supp.normraw import normaliser_sim
+
+print ("Building 3D phantom using TomoPhantom software")
+tic=timeit.default_timer()
+model = 9 # select a model number from the library
+N_size = 256 # Define phantom dimensions using a scalar value (cubic phantom)
+path = os.path.dirname(tomophantom.__file__)
+path_library3D = os.path.join(path, "Phantom3DLibrary.dat")
+#This will generate a N_size x N_size x N_size phantom (3D)
+phantom_tm = TomoP3D.Model(model, N_size, path_library3D)
+toc=timeit.default_timer()
+Run_time = toc - tic
+print("Phantom has been built in {} seconds".format(Run_time))
+
+sliceSel = int(0.5*N_size)
+#plt.gray()
+plt.figure() 
+plt.subplot(131)
+plt.imshow(phantom_tm[sliceSel,:,:],vmin=0, vmax=1)
+plt.title('3D Phantom, axial view')
+
+plt.subplot(132)
+plt.imshow(phantom_tm[:,sliceSel,:],vmin=0, vmax=1)
+plt.title('3D Phantom, coronal view')
+
+plt.subplot(133)
+plt.imshow(phantom_tm[:,:,sliceSel],vmin=0, vmax=1)
+plt.title('3D Phantom, sagittal view')
+plt.show()
+
+# Projection geometry related parameters:
+Horiz_det = int(np.sqrt(2)*N_size) # detector column count (horizontal)
+Vert_det = N_size # detector row count (vertical) (no reason for it to be > N)
+angles_num = int(0.5*np.pi*N_size); # angles number
+angles = np.linspace(0.0,179.9,angles_num,dtype='float32') # in degrees
+angles_rad = angles*(np.pi/180.0)
+#%%
+print ("Building 3D analytical projection data with TomoPhantom")
+projData3D_analyt= TomoP3D.ModelSino(model, N_size, Horiz_det, Vert_det, angles, path_library3D)
+
+intens_max = 70
+sliceSel = 150
+plt.figure() 
+plt.subplot(131)
+plt.imshow(projData3D_analyt[:,sliceSel,:],vmin=0, vmax=intens_max)
+plt.title('2D Projection (analytical)')
+plt.subplot(132)
+plt.imshow(projData3D_analyt[sliceSel,:,:],vmin=0, vmax=intens_max)
+plt.title('Sinogram view')
+plt.subplot(133)
+plt.imshow(projData3D_analyt[:,:,sliceSel],vmin=0, vmax=intens_max)
+plt.title('Tangentogram view')
+plt.show()
+#%%
+print ("Simulate flat fields, add noise and normalise projections...")
+flatsnum = 20 # generate 20 flat fields
+flatsSIM = flats(Vert_det, Horiz_det, maxheight = 0.1, maxthickness = 3, sigma_noise = 0.2, sigmasmooth = 3, flatsnum=flatsnum)
+
+plt.figure() 
+plt.imshow(flatsSIM[0,:,:],vmin=0, vmax=1)
+plt.title('A selected simulated flat-field')
+#%%
+# Apply normalisation of data and add noise
+flux_intensity = 10000 # controls the level of noise 
+sigma_flats = 0.06 # contro the level of noise in flats (higher creates ring artifacts)
+projData3D_norm = normaliser_sim(projData3D_analyt, flatsSIM, sigma_flats, flux_intensity)
+
+intens_max = 70
+sliceSel = 150
+plt.figure() 
+plt.subplot(131)
+plt.imshow(projData3D_norm[:,sliceSel,:],vmin=0, vmax=intens_max)
+plt.title('2D Projection (erroneous)')
+plt.subplot(132)
+plt.imshow(projData3D_norm[sliceSel,:,:],vmin=0, vmax=intens_max)
+plt.title('Sinogram view')
+plt.subplot(133)
+plt.imshow(projData3D_norm[:,:,sliceSel],vmin=0, vmax=intens_max)
+plt.title('Tangentogram view')
+plt.show()
+#%%
+# initialise TomoRec DIRECT reconstruction class ONCE
+from tomorec.methodsDIR import RecToolsDIR
+RectoolsDIR = RecToolsDIR(DetectorsDimH = Horiz_det,  # DetectorsDimH # detector dimension (horizontal)
+                    DetectorsDimV = Vert_det,  # DetectorsDimV # detector dimension (vertical) for 3D case only
+                    AnglesVec = angles_rad, # array of angles in radians
+                    ObjSize = N_size, # a scalar to define reconstructed object dimensions
+                    device = 'gpu')
+#%%
+print ("Reconstruction using FBP from TomoRec")
+recNumerical= RectoolsDIR.FBP(projData3D_norm) # FBP reconstruction
+
+sliceSel = int(0.5*N_size)
+max_val = 1
+#plt.gray()
+plt.figure() 
+plt.subplot(131)
+plt.imshow(recNumerical[sliceSel,:,:],vmin=0, vmax=max_val)
+plt.title('3D Reconstruction, axial view')
+
+plt.subplot(132)
+plt.imshow(recNumerical[:,sliceSel,:],vmin=0, vmax=max_val)
+plt.title('3D Reconstruction, coronal view')
+
+plt.subplot(133)
+plt.imshow(recNumerical[:,:,sliceSel],vmin=0, vmax=max_val)
+plt.title('3D Reconstruction, sagittal view')
+plt.show()
+
+# calculate errors 
+Qtools = QualityTools(phantom_tm, recNumerical)
+RMSE = Qtools.rmse()
+print("Root Mean Square Error is {}".format(RMSE))
+#%%
+print ("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")
+print ("Reconstructing with FISTA-OS method using TomoRec")
+print ("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")
+# initialise TomoRec ITERATIVE reconstruction class ONCE
+from tomorec.methodsIR import RecToolsIR
+RectoolsIR = RecToolsIR(DetectorsDimH = Horiz_det,  # DetectorsDimH # detector dimension (horizontal)
+                    DetectorsDimV = Vert_det,  # DetectorsDimV # detector dimension (vertical) for 3D case only
+                    AnglesVec = angles_rad, # array of angles in radians
+                    ObjSize = N_size, # a scalar to define reconstructed object dimensions
+                    datafidelity='LS',# data fidelity, choose LS, PWLS (wip), GH (wip), Student (wip)
+                    nonnegativity='ENABLE', # enable nonnegativity constraint (set to 'ENABLE')
+                    OS_number = 12, # the number of subsets, NONE/(or > 1) ~ classical / ordered subsets
+                    tolerance = 1e-07, # tolerance to stop outer iterations earlier
+                    device='gpu')
+lc = RectoolsIR.powermethod() # calculate Lipschitz constant
+#%%
+# Run FISTA reconstrucion algorithm without regularisation
+#RecFISTA = RectoolsIR.FISTA(projData3D_norm, iterationsFISTA = 5, lipschitz_const = lc)
+
+# Run FISTA reconstrucion algorithm with 3D regularisation
+RecFISTA_reg = RectoolsIR.FISTA(projData3D_norm, 
+                                iterationsFISTA = 7, 
+                                regularisation = 'FGP_TV', 
+                                regularisation_parameter = 0.007, 
+                                regularisation_iterations = 180,
+                                lipschitz_const = lc)
+
+sliceSel = int(0.5*N_size)
+max_val = 1
+plt.figure() 
+plt.subplot(131)
+plt.imshow(RecFISTA_reg[sliceSel,:,:],vmin=0, vmax=max_val)
+plt.title('3D FISTA Reconstruction, axial view')
+
+plt.subplot(132)
+plt.imshow(RecFISTA_reg[:,sliceSel,:],vmin=0, vmax=max_val)
+plt.title('3D FISTA Reconstruction, coronal view')
+
+plt.subplot(133)
+plt.imshow(RecFISTA_reg[:,:,sliceSel],vmin=0, vmax=max_val)
+plt.title('3D FISTA Reconstruction, sagittal view')
+plt.show()
+#%%

--- a/Wrappers/Python/tomophantom/supp/artifacts.py
+++ b/Wrappers/Python/tomophantom/supp/artifacts.py
@@ -4,16 +4,15 @@
 Created on Wed May  9 10:47:01 2018
 Note that the TomoPhantom package is released under Apache License, Version 2.0
 
-@author: Daniil Kazantsev
-
---- A class which simulates artifacts applied to a sinogram (2D) or to 3D 
-projection data
+Artifacts simulation class for sinograms (2D) or for 3D-projection data
  
 What can be simulated: 
 -- noise (Poisson or Gaussian)
 -- zingers (streaks in reconstructions)
 -- stripes (rings in reconstructions)
 -- shifts - misalignment (blur in reconstruction)
+
+@author: Daniil Kazantsev
 """
 import numpy as np
 import random
@@ -30,7 +29,7 @@ class ArtifactsClass:
         sino_noisy = self.sinogram
         if noisetype == 'Gaussian':
             # add normal Gaussian noise
-            sino_noisy += np.random.normal(loc = 0 ,scale = sigma * sino_noisy, size = np.shape(sino_noisy))
+            sino_noisy += np.random.normal(loc = 0.0, scale = sigma, size = np.shape(sino_noisy))
             sino_noisy[sino_noisy<0] = 0
         elif noisetype == 'Poisson':
             # add Poisson noise
@@ -85,7 +84,7 @@ class ArtifactsClass:
         return sino_zingers
     def stripes(self, percentage, maxthickness):
         """
-        function to add stripes (constant offsets) to sinogram which results in rings in the 
+        A function to add stripes (constant offsets) to sinogram which results in rings in the 
         reconstructed image
         - percentage defines the density of stripes
         - maxthickness defines maximal thickness of a stripe
@@ -123,7 +122,7 @@ class ArtifactsClass:
         return sino_stripes
     def shifts(self, maxamplitude):
         """
-        function to add random shifts to sinogram rows (an offset for each angular position)
+        A function to add random shifts to sinogram rows (an offset for each angular position)
         - maxamplitude (in pixels) defines the maximal amplitude of each angular deviation
         """
         sino_shifts = np.zeros(np.shape(self.sinogram),dtype='float32')

--- a/Wrappers/Python/tomophantom/supp/flatsgen.py
+++ b/Wrappers/Python/tomophantom/supp/flatsgen.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+A function to generate fake flat field images for 3D projection data normalisation
+"""
+
+from scipy.special import spherical_yn
+from scipy.special import y1
+from scipy.ndimage.filters import gaussian_filter
+import random
+import numpy as np
+# import matplotlib.pyplot as plt
+
+def flats(DetectorsDimV, DetectorsDimH, maxheight, maxthickness, sigma_noise, sigmasmooth, flatsnum):
+    """
+    maxheight - a value between (0,1] which controls the height of stripes
+    maxthickness - a value in pixels which controls the width of stripes
+    sigma_noise - a noise level (Gaussian) which is added to the sripe image
+    sigmasmooth - a smoothing parameter for a stripe image with noise (1,3,5,7...)
+    flatsnum - a number of flats to generate
+    """
+    
+    flatfield = np.zeros((DetectorsDimV,DetectorsDimH))
+    flat_combined3D = np.zeros((flatsnum,DetectorsDimV,DetectorsDimH))
+    
+    # using spherical Bessel functions
+    func = spherical_yn(1, np.linspace(3,15,DetectorsDimV,dtype='float32'))
+    func = func + abs(np.min(func))
+    func2 = y1(np.linspace(15,5,DetectorsDimH,dtype='float32'))
+    func2 = func2 + abs(np.min(func2))
+    
+    for i in range(0,DetectorsDimV):
+        flatfield[i,:] = func2
+    
+    for i in range(0,DetectorsDimH):
+        flatfield[:,i] += func
+    
+    # Adding stripes of varying vertical & horizontal sizes
+    maxheight_par = round(maxheight*DetectorsDimV)
+    max_intensity = np.max(flatfield)
+    flatstripes = np.zeros(np.shape(flatfield))
+    
+    for x in range(0,DetectorsDimH):
+        randind = random.randint(0,DetectorsDimV) # generate random index (vertically)
+        randthickness = random.randint(0,maxthickness) #generate random thickness
+        randheight = random.randint(0,maxheight_par) #generate random height
+        randintens = random.uniform(0.1, 2.0) # generate random multiplier
+        intensity = max_intensity*randintens
+        
+        for x1 in range(-randheight,randheight):
+            if (((randind+x1) >= 0) and ((randind+x1) < DetectorsDimV)):
+                for x2 in range(-randthickness,randthickness):
+                    if (((x+x2) >= 0) and ((x+x2) < DetectorsDimH)):
+                        flatstripes[randind+x1,x+x2] += intensity
+    
+    for i in range(0,flatsnum):
+        # adding noise and normalise
+        flatstripes2 = flatstripes.copy()
+        flatstripes2 += np.random.normal(loc = 0.00 ,scale = sigma_noise, size = np.shape(flatstripes2))
+        flatstripes2 /= np.max(flatstripes2)
+        flatstripes2 += abs(np.min(flatstripes2))
+        
+        #blur the result and add to the initial image with bessel background
+        blurred_flatstripes = gaussian_filter(flatstripes2, sigma=sigmasmooth)
+        flat_combined = flatfield + blurred_flatstripes
+        flat_combined /= np.max(flat_combined)
+        flat_combined3D[i,:,:] = flat_combined
+    return flat_combined3D

--- a/Wrappers/Python/tomophantom/supp/flatsgen.py
+++ b/Wrappers/Python/tomophantom/supp/flatsgen.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """
 A function to generate fake flat field images for 3D projection data normalisation
+
+@author: Daniil Kazantsev
 """
 
 from scipy.special import spherical_yn

--- a/Wrappers/Python/tomophantom/supp/normraw.py
+++ b/Wrappers/Python/tomophantom/supp/normraw.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+A function to normalise projection data using the generated flat fields. 
+Poisson noise is applied to flat fields and data
+"""
+import random
+import numpy as np
+import matplotlib.pyplot as plt
+from tomophantom.supp.artifacts import ArtifactsClass
+from flatsgen import flats
+
+# def normaliser2(DetectorsDimV, DetectorsDimH, maxheight, maxthickness, sigma_noise, sigmasmooth, flatsnum):
+"""
+maxheight - a value between (0,1] which controls the height of stripes
+
+"""
+flux_intensity = 30000
+flatsnum = 20
+sliceSel = 128
+
+[DetectorsDimV, DetectorsDimH] = np.shape(proj2D)
+flatsynth = flats(DetectorsDimV, DetectorsDimH, maxheight = 0.1, maxthickness = 3, sigma_noise = 0.3, sigmasmooth = 3, flatsnum=flatsnum)
+flat_average = np.average(flatsynth,0)
+
+artifacts_add = ArtifactsClass(flat_average)
+flat_average_noise = artifacts_add.noise(sigma=0.05,noisetype='Gaussian')
+# flat_average_noise /= np.max(flat_average_noise)
+#flat_average_noise = flat_average.copy()
+
+nonzeroInd = np.where(flat_average_noise != 0) # nonzero data
+zeroInd = np.where(flat_average_noise == 0) # zero data
+projData3D_norm = np.zeros(np.shape(projData3D_analyt),dtype='float32')
+
+for x in range(0,proj_num):
+    proj2D = projData3D_analyt[:,x,:]
+    norm_proj = np.zeros(np.shape(proj2D))
+    proj_noisy_flat = np.zeros(np.shape(proj2D))
+    randflatind = random.randint(0,flatsnum-1) # generate random flat number
+    selected_flat = flatsynth[randflatind,:,:]
+    artifacts_add = ArtifactsClass(proj2D)
+    proj2D_noisy = artifacts_add.noise(sigma=flux_intensity,noisetype='Poisson')
+    proj_noisy_flat[nonzeroInd] = selected_flat[nonzeroInd]*proj2D_noisy[nonzeroInd]
+    norm_proj[nonzeroInd]  = proj_noisy_flat[nonzeroInd]/flat_average_noise[nonzeroInd]
+    norm_proj[zeroInd] = 1e-13
+    projData3D_norm[:,x,:] = np.float32(norm_proj)
+
+#return flat_combined3D

--- a/Wrappers/Python/tomophantom/supp/normraw.py
+++ b/Wrappers/Python/tomophantom/supp/normraw.py
@@ -1,48 +1,54 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-A function to normalise projection data using the generated flat fields. 
-Poisson noise is applied to flat fields and data
+A function to normalise projection data using the generated flat fields, Poisson
+noise is applied to flat fields and data
+
+The errors in the flat fields will be propagated into prokjection data after
+normalisation. This can have a serious negative effect on the reconstructed images 
+in terms of the quality of reconstruction (artifacts presence). 
+
+This modelling, however, is more realistic and recommended if algorithms are 
+tested on robustness towards artifacts and errors in data
+
+@author: Daniil Kazantsev
 """
 import random
 import numpy as np
-import matplotlib.pyplot as plt
+#import matplotlib.pyplot as plt
 from tomophantom.supp.artifacts import ArtifactsClass
-from flatsgen import flats
 
-# def normaliser2(DetectorsDimV, DetectorsDimH, maxheight, maxthickness, sigma_noise, sigmasmooth, flatsnum):
-"""
-maxheight - a value between (0,1] which controls the height of stripes
+def normaliser_sim(projData3D, flatSIM, sigma_flats = 0.05, flux_intensity = 30000):
+    """
+    projData3D - 3D projection data (noiseless) [DetectorsDimV, Proj_angles, DetectorsDimH]
+    maxthickness - a value in pixels which controls the width of stripes
+    sigma_flats - a noise level (Gaussian) in flats, do not set too high to avoid outliers
+    flux_intensity  - controls the level of Posson noise applied to projection data
+    """
+    [DetectorsDimV, Proj_angles, DetectorsDimH] = np.shape(projData3D)
+    [flatsnum, DetectorsDimV_f, DetectorsDimH_f] = np.shape(flatSIM)
+    if (DetectorsDimV != DetectorsDimV_f):
+        raise("The size of the vertical detector for data and the flat field is different ")
+    if (DetectorsDimH != DetectorsDimH_f):
+        raise("The size of the horizontal detector for data and the flat field is different ")
+    # add noise to the stack of flat images
+    artifacts_add = ArtifactsClass(flatSIM)
+    flat_all_noise = artifacts_add.noise(sigma=sigma_flats,noisetype='Gaussian')
+    flat_average_noise = np.average(flat_all_noise,0) # calculate average of all flats
 
-"""
-flux_intensity = 30000
-flatsnum = 20
-sliceSel = 128
+    nonzeroInd = np.where(flat_average_noise != 0) # nonzero data
+    zeroInd = np.where(flat_average_noise == 0) # zero data
+    projData3D_norm = np.zeros(np.shape(projData3D),dtype='float32')
+    
+    for x in range(0,Proj_angles):
+        proj2D = projData3D[:,x,:]
+        norm_proj = np.zeros(np.shape(proj2D))
+        randflatind = random.randint(0,flatsnum-1) # generate random flat number
+        proj_flat = flatSIM[randflatind,:,:]*proj2D
+        artifacts_add = ArtifactsClass(proj_flat) # adding Poisson noise
+        proj_flat_noisy = artifacts_add.noise(sigma=flux_intensity,noisetype='Poisson')
+        norm_proj[nonzeroInd]  = proj_flat_noisy[nonzeroInd]/flat_average_noise[nonzeroInd]
+        norm_proj[zeroInd] = 1e-13
+        projData3D_norm[:,x,:] = np.float32(norm_proj)
 
-[DetectorsDimV, DetectorsDimH] = np.shape(proj2D)
-flatsynth = flats(DetectorsDimV, DetectorsDimH, maxheight = 0.1, maxthickness = 3, sigma_noise = 0.3, sigmasmooth = 3, flatsnum=flatsnum)
-flat_average = np.average(flatsynth,0)
-
-artifacts_add = ArtifactsClass(flat_average)
-flat_average_noise = artifacts_add.noise(sigma=0.05,noisetype='Gaussian')
-# flat_average_noise /= np.max(flat_average_noise)
-#flat_average_noise = flat_average.copy()
-
-nonzeroInd = np.where(flat_average_noise != 0) # nonzero data
-zeroInd = np.where(flat_average_noise == 0) # zero data
-projData3D_norm = np.zeros(np.shape(projData3D_analyt),dtype='float32')
-
-for x in range(0,proj_num):
-    proj2D = projData3D_analyt[:,x,:]
-    norm_proj = np.zeros(np.shape(proj2D))
-    proj_noisy_flat = np.zeros(np.shape(proj2D))
-    randflatind = random.randint(0,flatsnum-1) # generate random flat number
-    selected_flat = flatsynth[randflatind,:,:]
-    artifacts_add = ArtifactsClass(proj2D)
-    proj2D_noisy = artifacts_add.noise(sigma=flux_intensity,noisetype='Poisson')
-    proj_noisy_flat[nonzeroInd] = selected_flat[nonzeroInd]*proj2D_noisy[nonzeroInd]
-    norm_proj[nonzeroInd]  = proj_noisy_flat[nonzeroInd]/flat_average_noise[nonzeroInd]
-    norm_proj[zeroInd] = 1e-13
-    projData3D_norm[:,x,:] = np.float32(norm_proj)
-
-#return flat_combined3D
+    return projData3D_norm


### PR DESCRIPTION
* Adds new modules to simulate flat fields and normalise 3D projection data 
* demo provided

@paskino There is a problem. Somehow I cannot `from tomophantom.supp.flatsgen import flats` or `from tomophantom.supp.normraw import normaliser_sim` which are both in the folder. Please check, `DemoReconASTRA3D_sim.py` demo must work. Thanks!