### PR TITLE
Full switch to scikit-build-core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,13 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15...3.27)
+
+if (CMAKE_VERSION VERSION_LESS 3.18)
+  set(DEV_MODULE Development)
+else()
+  set(DEV_MODULE Development.Module)
+endif()
 
 project(tomophantom)
 
@@ -23,7 +29,10 @@ set (CIL_VERSION_PATCH 0)
 
 set (CIL_VERSION '${CIL_VERSION_MAJOR}.${CIL_VERSION_MINOR}.${CIL_VERSION_PATCH}' CACHE INTERNAL "Core Imaging Library version" FORCE)
 
-set(CMAKE_BUILD_TYPE "Release")
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
 
 option (BUILD_MATLAB_WRAPPER "Build Matlab Wrappers" OFF)
 option (BUILD_PYTHON_WRAPPER "Build Python Wrappers" OFF)

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -16,6 +16,15 @@ project(tomophantom)
 
 message("CIL_VERSION ${CIL_VERSION}")
 
+find_package(Python 3.8 COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)
+
+# Detect the installed nanobind package and import it into CMake
+# Remove execute_process when scipy-build-core is used
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
+
 find_package(OpenMP REQUIRED)
 if (OPENMP_FOUND)
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
@@ -33,67 +42,18 @@ message("CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS}")
 message("CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS}")
 message("CMAKE_STATIC_LINKER_FLAGS ${CMAKE_STATIC_LINKER_FLAGS}")
 
-set(CMAKE_BUILD_TYPE "Release")
-
-if(WIN32)
-  set (FLAGS "/DWIN32 /EHsc /DCCPi_EXPORTS /openmp:experimental")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS}")
-  set (CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS}")
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:MSVCRT.lib")  
-  set (EXTRA_LIBRARIES)		
-  message("library lib: ${LIBRARY_LIB}")  
-elseif(UNIX)
-   set (FLAGS "-O2 -funsigned-char -Wall -Wl,--no-undefined  -DCCPiReconstructionIterative_EXPORTS")  
-   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS}")
-   set (CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS}")
-   if (OPENMP_FOUND)
-     set (EXTRA_LIBRARIES 
-		"gomp"
-		"m"
-		)
-    else()
-       set (EXTRA_LIBRARIES 
-		"m"
-		)
-    endif()
-endif()
-message("CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}")
-
 message("Building TomoPhantom as a shared library")
-add_library(tomophantom "SHARED"
+nanobind_add_module(tomophantom "SHARED"
 	    ${CMAKE_CURRENT_SOURCE_DIR}/TomoP2DModel_core.c
 	    ${CMAKE_CURRENT_SOURCE_DIR}/TomoP2DModelSino_core.c
 	    ${CMAKE_CURRENT_SOURCE_DIR}/TomoP3DModel_core.c
 	    ${CMAKE_CURRENT_SOURCE_DIR}/TomoP3DModelSino_core.c
 	    ${CMAKE_CURRENT_SOURCE_DIR}/TomoP2DSinoNum_core.c
 	    ${CMAKE_CURRENT_SOURCE_DIR}/utils.c
+	    ${CMAKE_CURRENT_SOURCE_DIR}/bindings.c
 		)
 target_link_libraries(tomophantom ${EXTRA_LIBRARIES} )
 include_directories(tomophantom PUBLIC 
                       ${LIBRARY_INC}/include 
            	      ${CMAKE_CURRENT_SOURCE_DIR}
 		              )
-
-## Install
-set(PYTHON_SITE_DIR ${CMAKE_INSTALL_PREFIX}/source)
-set(CMAKE_POSITION_INDEPENDENT_CODE
-    ON
-    CACHE BOOL "Position independent code" FORCE)
-#set(INSTALL_BIN_DIR ${CMAKE_INSTALL_PREFIX}/bin)
-#set(INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib)
-#set(INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include)
-
-if (UNIX)
-message ("I'd install into ${CMAKE_INSTALL_PREFIX}/lib")
-install(TARGETS tomophantom
-	LIBRARY DESTINATION lib
-	CONFIGURATIONS ${CMAKE_BUILD_TYPE} 
-	)
-elseif(WIN32)
-message ("I'd install into ${CMAKE_INSTALL_PREFIX} lib bin")
-  install(TARGETS tomophantom 
-	RUNTIME DESTINATION bin
-	ARCHIVE DESTINATION lib
-	CONFIGURATIONS ${CMAKE_BUILD_TYPE} 
-	)
-endif()

--- a/Core/TomoP2DModelSino_core.c
+++ b/Core/TomoP2DModelSino_core.c
@@ -33,7 +33,7 @@
  */
 
 /* function to build a single sinogram - object */
-float TomoP2DObjectSino_core(float *A, int N, int P, float *Th, int AngTot, int CenTypeIn, char *Object, float C0, float x0, float y0, float a, float b, float phi_rot, int tt)
+float TomoP2DObjectSino_core(nb::ndarray<float> A, int N, int P, nb::ndarray<float> Th, int AngTot, int CenTypeIn, char *Object, float C0, float x0, float y0, float a, float b, float phi_rot, int tt)
 {
     int i, j;
     float *Tomorange_X_Ar=NULL, Tomorange_Xmin, Tomorange_Xmax, Sinorange_Pmax, Sinorange_Pmin, H_p, H_x, C1, a22, b22, phi_rot_radian;
@@ -53,7 +53,7 @@ float TomoP2DObjectSino_core(float *A, int N, int P, float *Th, int AngTot, int 
     H_x = (Tomorange_Xmax - Tomorange_Xmin)/(N);
     for(i=0; i<N; i++)  {Tomorange_X_Ar[i] = Tomorange_Xmin + (float)i*H_x;}
     AnglesRad = malloc(AngTot*sizeof(float));
-    for(i=0; i<AngTot; i++)  AnglesRad[i] = (Th[i])*((float)M_PI/180.0f) + M_PI;
+    for(i=0; i<AngTot; i++)  AnglesRad[i] = (Th.data()[i])*((float)M_PI/180.0f) + M_PI;
     
     C1 = -4.0f*logf(2.0f);
     
@@ -78,7 +78,7 @@ float TomoP2DObjectSino_core(float *A, int N, int P, float *Th, int AngTot, int 
     if (strcmp("gaussian",Object) == 0) {
         /* The object is a gaussian */
         AA5 = (N/2.0f)*(C0*(a)*(b)/2.0f)*sqrtf((float)M_PI/logf(2.0f));
-#pragma omp parallel for shared(A) private(i,j,sin_2,cos_2,delta1,delta_sq,first_dr,under_exp,AA2,AA3)
+#pragma omp parallel for shared(A.data()) private(i,j,sin_2,cos_2,delta1,delta_sq,first_dr,under_exp,AA2,AA3)
         for(i=0; i<AngTot; i++) {
             sin_2 = powf((sinf((AnglesRad[i]) - phi_rot_radian)),2);
             cos_2 = powf((cosf((AnglesRad[i]) - phi_rot_radian)),2);
@@ -89,7 +89,7 @@ float TomoP2DObjectSino_core(float *A, int N, int P, float *Th, int AngTot, int 
             for(j=0; j<P; j++) {
                 AA3 = powf((Sinorange_P_Ar[j] - AA2),2); /*(p-p0)^2*/
                 under_exp = (C1*AA3)*delta1;
-                A[tt*AngTot*P + j*AngTot+i] += first_dr*expf(under_exp);
+                A.data()[tt*AngTot*P + j*AngTot+i] += first_dr*expf(under_exp);
             }}
     }
     else if (strcmp("parabola",Object) == 0) {
@@ -114,7 +114,7 @@ float TomoP2DObjectSino_core(float *A, int N, int P, float *Th, int AngTot, int 
     else if (strcmp("ellipse",Object) == 0) {
         /* the object is an elliptical disk */
         AA5 = (N*C0*a*b);
-#pragma omp parallel for shared(A) private(i,j,sin_2,cos_2,delta1,delta_sq,first_dr,AA2,AA3,AA6)
+#pragma omp parallel for shared(A.data()) private(i,j,sin_2,cos_2,delta1,delta_sq,first_dr,AA2,AA3,AA6)
         for(i=0; i<AngTot; i++) {
             sin_2 = powf((sinf((AnglesRad[i]) - phi_rot_radian)),2);
             cos_2 = powf((cosf((AnglesRad[i]) - phi_rot_radian)),2);
@@ -126,14 +126,14 @@ float TomoP2DObjectSino_core(float *A, int N, int P, float *Th, int AngTot, int 
                 AA3 = powf((Sinorange_P_Ar[j] - AA2),2); /*(p-p0)^2*/
                 AA6 = (AA3)*delta1;
                 if (AA6 < 1.0f) {
-                    A[tt*AngTot*P + j*AngTot+i] += first_dr*sqrtf(1.0f - AA6);
+                    A.data()[tt*AngTot*P + j*AngTot+i] += first_dr*sqrtf(1.0f - AA6);
                 }
             }}
     }
     else if (strcmp("parabola1",Object) == 0) {
         /* the object is a parabola Lambda = 1 (12)*/
         AA5 = (N/2.0f)*(4.0f*((0.25f*(a)*(b)*C0)/2.5f));
-#pragma omp parallel for shared(A) private(i,j,sin_2,cos_2,delta1,delta_sq,first_dr,AA2,AA3,AA6)
+#pragma omp parallel for shared(A.data()) private(i,j,sin_2,cos_2,delta1,delta_sq,first_dr,AA2,AA3,AA6)
         for(i=0; i<AngTot; i++) {
             sin_2 = powf((sinf((AnglesRad[i]) - phi_rot_radian)),2);
             cos_2 = powf((cosf((AnglesRad[i]) - phi_rot_radian)),2);
@@ -145,7 +145,7 @@ float TomoP2DObjectSino_core(float *A, int N, int P, float *Th, int AngTot, int 
                 AA3 = powf((Sinorange_P_Ar[j] - AA2),2); /*(p-p0)^2*/
                 AA6 = AA3*delta1;
                 if (AA6 < 1.0f) {
-                    A[tt*AngTot*P + j*AngTot+i] += first_dr*(1.0f - AA6);
+                    A.data()[tt*AngTot*P + j*AngTot+i] += first_dr*(1.0f - AA6);
                 }
             }}
     }
@@ -153,7 +153,7 @@ float TomoP2DObjectSino_core(float *A, int N, int P, float *Th, int AngTot, int 
         /* the object is a cone */
         float pps2,rlogi,ty1;
         AA5 = (N/2.0f)*(a*b*C0);
-#pragma omp parallel for shared(A) private(i,j,sin_2,cos_2,delta1,delta_sq,first_dr,AA2,AA3,AA6,pps2,rlogi,ty1)
+#pragma omp parallel for shared(A.data()) private(i,j,sin_2,cos_2,delta1,delta_sq,first_dr,AA2,AA3,AA6,pps2,rlogi,ty1)
         for(i=0; i<AngTot; i++) {
             sin_2 = powf((sinf((AnglesRad[i]) - phi_rot_radian)),2);
             cos_2 = powf((cosf((AnglesRad[i]) - phi_rot_radian)),2);
@@ -174,7 +174,7 @@ float TomoP2DObjectSino_core(float *A, int N, int P, float *Th, int AngTot, int 
                     ty1 = (1.0f + pps2)/(1.0f - pps2);
                     if (ty1 > 0.0f) rlogi = 0.5f*AA6*logf(ty1);
                 }
-                A[tt*AngTot*P+ j*AngTot+i] += first_dr*(pps2 - rlogi);
+                A.data()[tt*AngTot*P+ j*AngTot+i] += first_dr*(pps2 - rlogi);
             }}
     }
     else if (strcmp("rectangle",Object) == 0) {
@@ -199,7 +199,7 @@ float TomoP2DObjectSino_core(float *A, int N, int P, float *Th, int AngTot, int 
         if (phi_rot_radian < 0)  {ksi1 = (float)M_PI + phi_rot_radian;}
         else ksi1 = phi_rot_radian;
         
-#pragma omp parallel for shared(A) private(i,j,PI2,p,ksi,C,S,A2,B2,FI,CF,SF,P0,TF,PC,QM,DEL,XSYC,QP,SS,p00,ksi00)
+#pragma omp parallel for shared(A.data()) private(i,j,PI2,p,ksi,C,S,A2,B2,FI,CF,SF,P0,TF,PC,QM,DEL,XSYC,QP,SS,p00,ksi00)
         for(i=0; i<AngTot; i++) {
             ksi00 = AnglesRad[(AngTot-1)-i] - M_PI;
             for(j=0; j<P; j++) {
@@ -258,7 +258,7 @@ float TomoP2DObjectSino_core(float *A, int N, int P, float *Th, int AngTot, int 
                 }
                 else SS = xwid/CF*C0;
                 if (PC >= QP) SS=0.0f;
-                A[tt*AngTot*P+ j*AngTot+i] += (N/2.0f)*SS;
+                A.data()[tt*AngTot*P+ j*AngTot+i] += (N/2.0f)*SS;
             }}
     }
     else {        
@@ -266,10 +266,10 @@ float TomoP2DObjectSino_core(float *A, int N, int P, float *Th, int AngTot, int 
     }
     /************************************************/
     free(Tomorange_X_Ar); free(Sinorange_P_Ar); free(AnglesRad);
-    return *A;
+    return *A.data();
 }
 
-float TomoP2DModelSino_core(float *A, int ModelSelected, int N, int P, float *Th, int AngTot, int CenTypeIn, char *ModelParametersFilename)
+float TomoP2DModelSino_core(nb::ndarrat< float > A, int ModelSelected, int N, int P, nb::ndarray< float > Th, int AngTot, int CenTypeIn, char *ModelParametersFilename)
 {    
     int Model=0, Components=0, steps = 0, counter=0, ii;
     float C0 = 0.0f, x0 = 0.0f, y0 = 0.0f, a = 0.0f, b = 0.0f, psi_gr1 = 0.0f;

--- a/Core/TomoP2DModelSino_core.h
+++ b/Core/TomoP2DModelSino_core.h
@@ -19,5 +19,9 @@ limitations under the License.
 #include "omp.h"
 #include "CCPiDefines.h"
 
-CCPI_EXPORT float TomoP2DModelSino_core(float *A, int ModelSelected, int N, int P, float *Th, int AngTot, int CenTypeIn, char* ModelParametersFilename);
-CCPI_EXPORT float TomoP2DObjectSino_core(float *A, int N, int P, float *Th, int AngTot, int CenTypeIn, char* Obj, float C0, float x0, float y0, float a, float b, float phi_rot, int tt);
+#include <nanobind/ndarray.h>
+
+
+
+float TomoP2DModelSino_core(nb::ndarray<float> A, int ModelSelected, int N, int P, nb::ndarray<float> Th, int AngTot, int CenTypeIn, char* ModelParametersFilename);
+float TomoP2DObjectSino_core(nb::ndarray<float> A, int N, int P, nb::ndarray<float> Th, int AngTot, int CenTypeIn, char* Obj, float C0, float x0, float y0, float a, float b, float phi_rot, int tt);

--- a/Core/TomoP2DModel_core.c
+++ b/Core/TomoP2DModel_core.c
@@ -35,7 +35,7 @@
  */
 
 /* function to build a single object */
-float TomoP2DObject_core(float *A, int N, char *Object,
+float TomoP2DObject_core(nb::ndarray<float> A, int N, char *Object,
         float C0, /* intensity */
         float x0, /* x0 position */
         float y0, /* y0 position */
@@ -73,55 +73,55 @@ float TomoP2DObject_core(float *A, int N, char *Object,
     /* all parameters of an object have been extracted, now run the building modules */
     if (strcmp("gaussian",Object) == 0) {
         /* The object is a gaussian */
-#pragma omp parallel for shared(A) private(i,j,T)
+#pragma omp parallel for shared(A.data()) private(i,j,T)
         for(i=0; i<N; i++) {
             for(j=0; j<N; j++) {
                 T = C1*(a2*powf((Xdel[i]*cos_phi + Ydel[j]*sin_phi),2) + b2*powf((-Xdel[i]*sin_phi + Ydel[j]*cos_phi),2));
-                A[tt*N*N + j*N+i] += C0*expf(T);
+                A.data()[tt*N*N + j*N+i] += C0*expf(T);
             }}
     }
     else if (strcmp("parabola",Object) == 0) {
         /* the object is a parabola Lambda = 1/2 */
-#pragma omp parallel for shared(A) private(i,j,T)
+#pragma omp parallel for shared(A.data()) private(i,j,T)
         for(i=0; i<N; i++) {
             for(j=0; j<N; j++) {
                 T = a2*powf((Xdel[i]*cos_phi + Ydel[j]*sin_phi),2) + b2*powf((-Xdel[i]*sin_phi + Ydel[j]*cos_phi),2);
                 if (T <= 1) T = C0*sqrtf(1.0f - T);
                 else T = 0.0f;
-                A[tt*N*N + j*N+i] += T;
+                A.data()[tt*N*N + j*N+i] += T;
             }}
     }
     else if (strcmp("ellipse",Object) == 0) {
         /* the object is an elliptical disk */
-#pragma omp parallel for shared(A) private(i,j,T)
+#pragma omp parallel for shared(A.data()) private(i,j,T)
         for(i=0; i<N; i++) {
             for(j=0; j<N; j++) {
                 T = a2*powf((Xdel[i]*cos_phi + Ydel[j]*sin_phi),2) + b2*powf((-Xdel[i]*sin_phi + Ydel[j]*cos_phi),2);
                 if (T <= 1) T = C0;
                 else T = 0.0f;
-                A[tt*N*N + j*N+i] += T;
+                A.data()[tt*N*N + j*N+i] += T;
             }}
     }
     else if (strcmp("parabola1",Object) == 0) {
         /* the object is a parabola Lambda = 1*/
-#pragma omp parallel for shared(A) private(i,j,T)
+#pragma omp parallel for shared(A.data()) private(i,j,T)
         for(i=0; i<N; i++) {
             for(j=0; j<N; j++) {
                 T = (4.0f*a2)*powf((Xdel[i]*cos_phi + Ydel[j]*sin_phi),2) + (4.0f*b2)*powf((-Xdel[i]*sin_phi + Ydel[j]*cos_phi),2);
                 if (T <= 1) T = C0*sqrtf(1.0f - T);
                 else T = 0.0f;
-                A[tt*N*N + j*N+i] += T;
+                A.data()[tt*N*N + j*N+i] += T;
             }}
     }
     else if (strcmp("cone",Object) == 0) {
         /*the object is a cone*/
-#pragma omp parallel for shared(A) private(i,j,T)
+#pragma omp parallel for shared(A.data()) private(i,j,T)
         for(i=0; i<N; i++) {
             for(j=0; j<N; j++) {
                 T = a2*powf((Xdel[i]*cos_phi + Ydel[j]*sin_phi),2) + b2*powf((-Xdel[i]*sin_phi + Ydel[j]*cos_phi),2);
                 if (T <= 1) T = C0*(1.0f - sqrtf(T));
                 else T = 0.0f;
-                A[tt*N*N + j*N+i] += T;
+                A.data()[tt*N*N + j*N+i] += T;
             }}
     }
     else if (strcmp("rectangle",Object) == 0) {
@@ -136,7 +136,7 @@ float TomoP2DObject_core(float *A, int N, char *Object,
             sin_phi=sinf(phi_rot_radian);
             cos_phi=cosf(phi_rot_radian);
         }
-#pragma omp parallel for shared(A) private(i,j,HX,HY,T)
+#pragma omp parallel for shared(A.data()) private(i,j,HX,HY,T)
         for(i=0; i<N; i++) {
             for(j=0; j<N; j++) {
                 HX = fabsf((Xdel[i] - x0r)*sin_phi + (Ydel[j] - y0r)*cos_phi);
@@ -145,7 +145,7 @@ float TomoP2DObject_core(float *A, int N, char *Object,
                     HY = fabsf((Ydel[j] - y0r)*sin_phi - (Xdel[i] - x0r)*cos_phi);
                     if (HY <= b2) {T = C0;}
                 }
-                A[tt*N*N + j*N+i] += T;
+                A.data()[tt*N*N + j*N+i] += T;
             }}
     }
     else {        
@@ -157,7 +157,7 @@ float TomoP2DObject_core(float *A, int N, char *Object,
     return *A;
 }
 
-float TomoP2DModel_core(float *A, int ModelSelected, int N, char *ModelParametersFilename)
+float TomoP2DModel_core(nb::ndarray<float> A, int ModelSelected, int N, char *ModelParametersFilename)
 {
     FILE *fp = fopen(ModelParametersFilename, "r"); // read parameters file    
     int Model=0, Components=0, steps = 0, counter=0, ii;

--- a/Core/TomoP2DModel_core.h
+++ b/Core/TomoP2DModel_core.h
@@ -20,6 +20,8 @@ limitations under the License.
 #include "omp.h"
 #include "CCPiDefines.h"
 
+#include <nanobind/ndarray.h>
 
-CCPI_EXPORT float TomoP2DModel_core(float *A, int ModelSelected, int N, char *ModelParametersFilename);
-CCPI_EXPORT float TomoP2DObject_core(float *A, int N,  char *Object, float C0, float x0, float y0, float a, float b, float phi_rot, int tt);
+
+float TomoP2DModel_core(nb::ndarray<float> A, int ModelSelected, int N, char *ModelParametersFilename);
+float TomoP2DObject_core(nb::ndarray<float> A, int N,  char *Object, float C0, float x0, float y0, float a, float b, float phi_rot, int tt);

--- a/Core/TomoP2DSinoNum_core.c
+++ b/Core/TomoP2DSinoNum_core.c
@@ -42,7 +42,7 @@
  */
  
 
-float TomoP2DSinoNum_core(float *Sinogram, float *Phantom, int dimX, int DetSize, float *Theta, int ThetaLength, int sys)
+float TomoP2DSinoNum_core(nb::ndarray< float > Sinogram, nb::ndarray< float > Phantom, int dimX, int DetSize, nb::ndarray< float > Theta, int ThetaLength, int sys)
 {    
 	int i, j, k, padXY;
 	float *Phantom_pad=NULL, *B=NULL,  angC, ct, st, sumSin;
@@ -51,15 +51,15 @@ float TomoP2DSinoNum_core(float *Sinogram, float *Phantom, int dimX, int DetSize
     
     /*Perform padding of the phantom to the size [DetSize x DetSize] */
     Phantom_pad = (float*) calloc(DetSize*DetSize,sizeof(float));  /*allocating space*/
-    padding(Phantom, Phantom_pad, DetSize, dimX, padXY, sys);
+    padding(Phantom.data(), Phantom_pad, DetSize, dimX, padXY, sys);
     
     /* setting OMP here */
-    #pragma omp parallel for shared (Phantom_pad, Sinogram, dimX, DetSize, Theta, ThetaLength) private(B, k, j, i, sumSin, angC, ct, st)    
+    #pragma omp parallel for shared (Phantom_pad, Sinogram.data(), dimX, DetSize, Theta.data(), ThetaLength) private(B, k, j, i, sumSin, angC, ct, st)    
     for (k=0; k < ThetaLength; k++) {
         
         B = (float*) calloc(DetSize*DetSize,sizeof(float));
         
-        angC = Theta[k]*M_PI/180.0f;
+        angC = Theta.data()[k]*M_PI/180.0f;
         ct = cos(angC + 0.5f*M_PI);
         st = sin(angC + 0.5f*M_PI);
         
@@ -67,19 +67,19 @@ float TomoP2DSinoNum_core(float *Sinogram, float *Phantom, int dimX, int DetSize
         
         for (j=0; j < DetSize; j++) {
             sumSin = 0.0f;
-            Sinogram[j*ThetaLength + k] = 0.0f;
+            Sinogram.data()[j*ThetaLength + k] = 0.0f;
             for (i=0; i < DetSize; i++) sumSin += B[i*DetSize+j];
-            Sinogram[j*ThetaLength + k] = sumSin;
+            Sinogram.data()[j*ThetaLength + k] = sumSin;
         }
         free(B);
     }    
     
     /*freeing the memory*/
    free(Phantom_pad);
-   return  *Sinogram;     
+   return  *Sinogram.data();     
 }    
 
-float BilinearInterpolation(float *Phantom_pad, float *B, int DetSize, float ct, float st)
+float BilinearInterpolation(nb::ndarray < float > Phantom_pad, nd::ndarray< float > B, int DetSize, float ct, float st)
 {
     int i, j, k, i0, j0, i1, j1;
     float *xs, H_x, s_min, s_max, stepS, x_rs, y_rs, dhalf, xbar, ybar;
@@ -110,24 +110,24 @@ float BilinearInterpolation(float *Phantom_pad, float *B, int DetSize, float ct,
             i0 = i0+1; j0=j0+1;
             
             if ((i0 < DetSize) && (j0 < DetSize)) {
-                B[i*DetSize+j] = Phantom_pad[i0*DetSize+j0]*(1.-xbar)*(1.-ybar)+Phantom_pad[(i0+1)*DetSize+j0]*ybar*(1.-xbar)+Phantom_pad[i0*DetSize+(j0+1)]*xbar*(1.-ybar)+Phantom_pad[(i0+1)*DetSize+(j0+1)]*xbar*ybar;
+                B.data()[i*DetSize+j] = Phantom_pad.data()[i0*DetSize+j0]*(1.-xbar)*(1.-ybar)+Phantom_pad.data()[(i0+1)*DetSize+j0]*ybar*(1.-xbar)+Phantom_pad.data()[i0*DetSize+(j0+1)]*xbar*(1.-ybar)+Phantom_pad.data()[(i0+1)*DetSize+(j0+1)]*xbar*ybar;
             }
         }}
     free(xs);
-    return *B;
+    return *B.data();
 }
 
-float padding(float *Phantom, float *Phantom_pad, int DetSize, int PhantSize, int padXY, int sys)
+float padding(nb::ndarray< float > Phantom, nb::ndarray< float > Phantom_pad, int DetSize, int PhantSize, int padXY, int sys)
 {
     int i,j;   
-    #pragma omp parallel for shared (Phantom_pad, Phantom) private(i, j)
+    #pragma omp parallel for shared (Phantom_pad.data(), Phantom.data()) private(i, j)
     for (i=0; i < DetSize; i++) {
         for (j=0; j < DetSize; j++) {
-            Phantom_pad[j*DetSize+i] = 0.0f;
+            Phantom_pad.data()[j*DetSize+i] = 0.0f;
              if (((i >= padXY+1) && (i < DetSize-padXY)) &&  ((j >= padXY) && (j < DetSize-padXY))) {
-                  if (sys == 0) Phantom_pad[j*DetSize+i] = Phantom[(i-padXY)*PhantSize + (j-padXY)];
-                  else Phantom_pad[j*DetSize+i] = Phantom[(j-padXY)*PhantSize + (i-padXY)];
+                  if (sys == 0) Phantom_pad.data()[j*DetSize+i] = Phantom.data()[(i-padXY)*PhantSize + (j-padXY)];
+                  else Phantom_pad.data()[j*DetSize+i] = Phantom.data()[(j-padXY)*PhantSize + (i-padXY)];
              }
         }}
-    return *Phantom_pad;
+    return *Phantom_pad.data();
 }

--- a/Core/TomoP2DSinoNum_core.h
+++ b/Core/TomoP2DSinoNum_core.h
@@ -19,6 +19,6 @@ limitations under the License.
 #include "omp.h"
 #include "CCPiDefines.h"
 
-CCPI_EXPORT float TomoP2DSinoNum_core(float *Sinogram, float *Phantom, int dimX, int DetSize, float *Theta, int ThetaLength, int sys);
-CCPI_EXPORT float BilinearInterpolation(float *Phantom_pad, float *B, int DetSize, float ct, float st);
-CCPI_EXPORT float padding(float *Phantom, float *Phantom_pad, int DetSize, int PhantSize, int padXY, int sys);
+float TomoP2DSinoNum_core(nb::ndarray<float> Sinogram, nb::ndarray<float> Phantom, int dimX, int DetSize, nb::ndarray<float> Theta, int ThetaLength, int sys);
+float BilinearInterpolation(nb::ndarray<float> Phantom_pad, nb::ndarray<float> B, int DetSize, float ct, float st);
+float padding(nb::ndarray<float> Phantom, nb::ndarray<float> Phantom_pad, int DetSize, int PhantSize, int padXY, int sys);

--- a/Core/TomoP3DModelSino_core.c
+++ b/Core/TomoP3DModelSino_core.c
@@ -43,7 +43,7 @@
  *
  */
 
-float TomoP3DObjectSino_core(float *A, long Horiz_det, long Vert_det, long Z1, long Z2, long N, float *Theta_proj, int AngTot, char *Object,
+float TomoP3DObjectSino_core(nb::ndarray< float > A, long Horiz_det, long Vert_det, long Z1, long Z2, long N, nb::ndarray< float > Theta_proj, int AngTot, char *Object,
         float C0, /* intensity */
         float x0, /* x0 position */
         float y0, /* y0 position */
@@ -93,7 +93,7 @@ float TomoP3DObjectSino_core(float *A, long Horiz_det, long Vert_det, long Z1, l
     
     /* convert to radians */
     AnglesRad = malloc(AngTot*sizeof(float));
-    for(ll=0; ll<AngTot; ll++)  AnglesRad[ll] = (Theta_proj[ll])*((float)M_PI/180.0f);
+    for(ll=0; ll<AngTot; ll++)  AnglesRad[ll] = (Theta_proj.data()[ll])*((float)M_PI/180.0f);
     
     float alog2 = logf(2.0f);
     multiplier = (C0*(N/2.0f));
@@ -176,7 +176,7 @@ float TomoP3DObjectSino_core(float *A, long Horiz_det, long Vert_det, long Z1, l
                 AA5 = (N*C0*a*b);
                 
                 /*printf("%s %f %f %f %f %f %f %f %f %f %f %ld\n", Object, C0, x0, y0, z0, a, b, c, psi_gr1, psi_gr2, psi_gr3, tt);*/
-#pragma omp parallel for shared(A) private(index,k,j,ll,TETAs,FIs,PSIs,aa1,aa,FI1,TETA1,PSI1,ai,bsai,vh1,al,a_v,b_v,c_v,d_v,p1,p2,alh,bth,gmh,sin_2, cos_2,delta1,delta_sq,first_dr, AA2, AA3, AA6, p00,ksi00,p,ksi,C,S,A2,B2,FI,CF,SF,P0,TF,PC,QM,DEL,XSYC,QP,SS)
+#pragma omp parallel for shared(A.data()) private(index,k,j,ll,TETAs,FIs,PSIs,aa1,aa,FI1,TETA1,PSI1,ai,bsai,vh1,al,a_v,b_v,c_v,d_v,p1,p2,alh,bth,gmh,sin_2, cos_2,delta1,delta_sq,first_dr, AA2, AA3, AA6, p00,ksi00,p,ksi,C,S,A2,B2,FI,CF,SF,P0,TF,PC,QM,DEL,XSYC,QP,SS)
                 for(ll=0; ll<AngTot; ll++) {
                     
                     TETAs = AnglesRad[ll]; /* the variable projection angle (AnglesRad) */
@@ -222,7 +222,7 @@ float TomoP3DObjectSino_core(float *A, long Horiz_det, long Vert_det, long Z1, l
                                 if(d_v > 0) {
                                     p1 = -(sqrtf(d_v)+b_v)/a_v;
                                     p2 = (sqrtf(d_v)-b_v)/a_v;
-                                    A[index] += (p2-p1)*multiplier;
+                                    A.data()[index] += (p2-p1)*multiplier;
                                 }
                             }
                             if (strcmp("paraboloid",Object) == 0) {
@@ -235,7 +235,7 @@ float TomoP3DObjectSino_core(float *A, long Horiz_det, long Vert_det, long Z1, l
                                 if(d_v > 0) {
                                     p1 = -(sqrtf(d_v)+b_v)/a_v;
                                     p2 = (sqrtf(d_v)-b_v)/a_v;
-                                    A[index] += multiplier*(a_v/3.0f*(pow(p1,3.0f) - pow(p2,3.0f)) +  b_v*(pow(p1,2.0f) - pow(p2,2.0f)) + c_v*(p1-p2));
+                                    A.data()[index] += multiplier*(a_v/3.0f*(pow(p1,3.0f) - pow(p2,3.0f)) +  b_v*(pow(p1,2.0f) - pow(p2,2.0f)) + c_v*(p1-p2));
                                 }
                             }
                             if (strcmp("gaussian",Object) == 0) {
@@ -248,7 +248,7 @@ float TomoP3DObjectSino_core(float *A, long Horiz_det, long Vert_det, long Z1, l
                                 b_v = aa[0]*alh*(al[0]-xh[0]) + aa[1]*bth*(al[1]-xh[1]) + aa[2]*gmh*(al[2]-xh[2]);
                                 c_v = alh*powf(((al[0]-xh[0])),2) + bth*powf(((al[1]-xh[1])),2) + gmh*powf(((al[2]-xh[2])),2);
                                 
-                                A[index] += multiplier*sqrtf(M_PI*a_v)*expf((pow(b_v,2))*a_v-c_v);
+                                A.data()[index] += multiplier*sqrtf(M_PI*a_v)*expf((pow(b_v,2))*a_v-c_v);
                             }
                         }} /*main for j-k loop*/
                     
@@ -267,7 +267,7 @@ float TomoP3DObjectSino_core(float *A, long Horiz_det, long Vert_det, long Z1, l
                                     AA6 = (AA3)*delta1;
                                     //index = tt*Vert_det*Horiz_det*AngTot + ll*Vert_det*Horiz_det + k*Horiz_det + j;
                                     index = tt*sub_vol_size*Horiz_det*AngTot + ll*sub_vol_size*Horiz_det + (k - Z1)*Horiz_det + j;
-                                    if (AA6 < 1.0f) A[index] += first_dr*sqrtf(1.0f - AA6);
+                                    if (AA6 < 1.0f) A.data()[index] += first_dr*sqrtf(1.0f - AA6);
                                 }
                             }
                         }
@@ -331,7 +331,7 @@ float TomoP3DObjectSino_core(float *A, long Horiz_det, long Vert_det, long Z1, l
                                     else SS = xwid/CF*C0;
                                     if (PC >= QP) SS=0.0f;
                                     
-                                    A[index] += (N/2.0f)*SS;
+                                    A.data()[index] += (N/2.0f)*SS;
                                 } /*j-loop*/
                             }
                         } /*k-loop*/
@@ -343,11 +343,11 @@ float TomoP3DObjectSino_core(float *A, long Horiz_det, long Vert_det, long Z1, l
                 free(DetectorRange_Vert_ar);
                 free(Tomorange_Z_Ar);
                 free(Zdel);
-                return *A;
+                return *A.data();
 }
 
 /********************Core Function*****************************/
-float TomoP3DModelSino_core(float *A, int ModelSelected, long Horiz_det, long Vert_det, long Z1, long Z2, long N, float *Angl_vector, int AngTot, char* ModelParametersFilename)
+float TomoP3DModelSino_core(nb::ndarray< float > A, int ModelSelected, long Horiz_det, long Vert_det, long Z1, long Z2, long N, nb::ndarray< float > Angl_vector, int AngTot, char* ModelParametersFilename)
 {
     
     int Model = 0, Components = 0, steps = 0, counter = 0, ii;
@@ -554,7 +554,7 @@ float TomoP3DModelSino_core(float *A, int ModelSelected, long Horiz_det, long Ve
         }
     }
     fclose(fp);
-    return *A;
+    return *A.data();
 }
 
 

--- a/Core/TomoP3DModelSino_core.h
+++ b/Core/TomoP3DModelSino_core.h
@@ -20,8 +20,8 @@ limitations under the License.
 #include "CCPiDefines.h"
 #include "utils.h"
 
-CCPI_EXPORT float TomoP3DModelSino_core(float *A, int ModelSelected, long Horiz_det, long Vert_det, long Z1, long Z2, long N, float *Theta_proj, int AngTot, char* ModelParametersFilename);
-CCPI_EXPORT float TomoP3DObjectSino_core(float *A, long Horiz_det, long Vert_det, long Z1, long Z2, long N, float *Angl_vector, int AngTot, char *Object,
+float TomoP3DModelSino_core(nb::ndarray<float> A, int ModelSelected, long Horiz_det, long Vert_det, long Z1, long Z2, long N, nb::ndarray<float> Theta_proj, int AngTot, char* ModelParametersFilename);
+float TomoP3DObjectSino_core(nb::ndarray<float> A, long Horiz_det, long Vert_det, long Z1, long Z2, long N, nb::ndarray<float> Angl_vector, int AngTot, char *Object,
 	float C0, /* longensity */
 	float x0, /* x0 position */
 	float y0, /* y0 position */

--- a/Core/TomoP3DModel_core.c
+++ b/Core/TomoP3DModel_core.c
@@ -41,7 +41,7 @@
 */
 
 /* function to build a single (stationary) object */
-float TomoP3DObject_core(float *A, long N1, long N2, long N3, long Z1, long Z2, char *Object,
+float TomoP3DObject_core(nb::ndarray< float > A, long N1, long N2, long N3, long Z1, long Z2, char *Object,
 	float C0, /* intensity */
 	float x0, /* x0 position */
 	float y0, /* y0 position */
@@ -123,7 +123,7 @@ float TomoP3DObject_core(float *A, long N1, long N2, long N3, long Z1, long Z2, 
 	
 	if ((strcmp("gaussian", Object) == 0) || (strcmp("paraboloid", Object) == 0) || (strcmp("ellipsoid", Object) == 0) || (strcmp("cone", Object) == 0)) 
 	{
-#pragma omp parallel for shared(A,bs) private(k,i,j,index,aa,bb,cc,T,xh2,xh1)
+#pragma omp parallel for shared(A.data(),bs) private(k,i,j,index,aa,bb,cc,T,xh2,xh1)
 		for (k = Z1; k<Z2; k++) {
 			for (i = 0; i<N1; i++) {
 				for (j = 0; j<N2; j++) {
@@ -163,7 +163,7 @@ float TomoP3DObject_core(float *A, long N1, long N2, long N3, long Z1, long Z2, 
 						if (T <= 1.0f) T = C0*(1.0f - sqrtf(T));
 						else T = 0.0f;
 					}
-						A[index] += T;												
+						A.data()[index] += T;												
 				}
 			}
 		}
@@ -181,7 +181,7 @@ float TomoP3DObject_core(float *A, long N1, long N2, long N3, long Z1, long Z2, 
 			sin_phi = sinf(phi_rot_radian);
 			cos_phi = cosf(phi_rot_radian);
 		}
-#pragma omp parallel for shared(A,Zdel) private(k,i,j,HX,HY,T)
+#pragma omp parallel for shared(A.data(),Zdel) private(k,i,j,HX,HY,T)
 		for (k = Z1; k<Z2; k++) {
 			if (fabs(Zdel[k]) < c2) {
 				for (i = 0; i<N1; i++) {
@@ -193,7 +193,7 @@ float TomoP3DObject_core(float *A, long N1, long N2, long N3, long Z1, long Z2, 
 							if (HY <= b2) { T = C0; }
 						}
 						
-							A[tt*N1*N2*sub_vol_size + (k - Z1)*N1*N2 + j*N1 + i] += T;
+							A.data()[tt*N1*N2*sub_vol_size + (k - Z1)*N1*N2 + j*N1 + i] += T;
 						
 					}
 				}
@@ -202,7 +202,7 @@ float TomoP3DObject_core(float *A, long N1, long N2, long N3, long Z1, long Z2, 
 	}
 	if (strcmp("elliptical_cylinder", Object) == 0) {
 		/* the object is an elliptical cylinder  */
-#pragma omp parallel for shared(A) private(k,i,j,T)
+#pragma omp parallel for shared(A.data()) private(k,i,j,T)
 		for (k = Z1; k<Z2; k++) {
 			if (fabs(Zdel[k]) < c) {
 				for (i = 0; i<N1; i++) {
@@ -211,7 +211,7 @@ float TomoP3DObject_core(float *A, long N1, long N2, long N3, long Z1, long Z2, 
 						if (T <= 1) T = C0;
 						else T = 0.0f;
 						
-							A[tt*N1*N2*sub_vol_size + (k - Z1)*N1*N2 + j*N1 + i] += T;
+							A.data()[tt*N1*N2*sub_vol_size + (k - Z1)*N1*N2 + j*N1 + i] += T;
 						
 					}
 				}
@@ -221,11 +221,11 @@ float TomoP3DObject_core(float *A, long N1, long N2, long N3, long Z1, long Z2, 
 	/****************************************************/
 	free(Xdel); free(Ydel); free(Zdel);
 	free(Tomorange_X_Ar); free(Tomorange_Y_Ar); free(Tomorange_Z_Ar);
-	return *A;
+	return *A.data();
 }
 
 /********************Core Function*****************************/
-float TomoP3DModel_core(float *A, int ModelSelected, long N1, long N2, long N3, long Z1, long Z2, char *ModelParametersFilename)
+float TomoP3DModel_core(nb::ndarray< float > A, int ModelSelected, long N1, long N2, long N3, long Z1, long Z2, char *ModelParametersFilename)
 {
 
 	int Model = 0, Components = 0, steps = 0, counter = 0, ii;
@@ -308,7 +308,7 @@ float TomoP3DModel_core(float *A, int ModelSelected, long N1, long N2, long N3, 
 								}
 								// printf("\nObject : %s \nC0 : %f \nx0 : %f \ny0 : %f \nz0 : %f \na : %f \nb : %f \nc : %f \n", tmpstr2, C0, x0, y0, z0, a, b, c);                                                          
 
-								TomoP3DObject_core(A, N1, N2, N3, Z1, Z2, tmpstr2, C0, y0, x0, z0, a, b, c, psi_gr1, psi_gr2, psi_gr3, 0l); /* python */
+								TomoP3DObject_core(A.data(), N1, N2, N3, Z1, Z2, tmpstr2, C0, y0, x0, z0, a, b, c, psi_gr1, psi_gr2, psi_gr3, 0l); /* python */
 							}
 						}
 						else {
@@ -419,5 +419,5 @@ float TomoP3DModel_core(float *A, int ModelSelected, long N1, long N2, long N3, 
 		}
 	}
 	fclose(fp);
-	return *A;
+	return *A.data();
 }

--- a/Core/TomoP3DModel_core.h
+++ b/Core/TomoP3DModel_core.h
@@ -21,8 +21,8 @@ limitations under the License.
 #include "CCPiDefines.h"
 #include "utils.h"
 
-CCPI_EXPORT float TomoP3DModel_core(float *A, int ModelSelected, long N1, long N2, long N3, long Z1, long Z2, char *ModelParametersFilename);
-CCPI_EXPORT float TomoP3DObject_core(float *A, long N1, long N2, long N3, long Z1, long Z2, char *Object,
+float TomoP3DModel_core(nb::ndarray<float> A, int ModelSelected, long N1, long N2, long N3, long Z1, long Z2, char *ModelParametersFilename);
+float TomoP3DObject_core(nb::ndarray<float> A, long N1, long N2, long N3, long Z1, long Z2, char *Object,
 	float C0, /* intensity */
 	float x0, /* x0 position */
 	float y0, /* y0 position */

--- a/Core/bindings.c
+++ b/Core/bindings.c
@@ -1,0 +1,32 @@
+#include "TomoP2DModelSino_core.h"
+#include "TomoP2DModel_core.h"
+#include "TomoP2DSinoNum_core.h"
+#include "TomoP3DModelSino_core.h"
+#include "TomoP3DModel_core.h"
+#include "utils.h"
+
+#include <nanobind/nanobind.h>
+
+NB_MODULE(nanobind, m) {
+  m.def("TomoP2DModel_core", &TomoP2DModel_core);
+  m.def("TomoP2DObject_core", &TomoP2DObject_core);
+
+  m.def("TomoP2DModelSino_core", &TomoP2DModelSino_core);
+  m.def("TomoP2DObjectSino_core", &TomoP2DObjectSino_core);
+
+  m.def("TomoP2DSinoNum_core", &TomoP2DSinoNum_core);
+  m.def("BilinearInterpolation", &BilinearInterpolation);
+  m.def("padding", &padding);
+
+  m.def("TomoP3DModel_core", &TomoP3DModel_core);
+  m.def("TomoP3DObject_core", &TomoP3DObject_core);
+
+  m.def("TomoP3DModelSino_core", &TomoP3DModelSino_core);
+  m.def("TomoP3DObjectSino_core", &TomoP3DObjectSino_core);
+
+  m.def("checkParams2D", &checkParams2D);
+  m.def("checkParams3D", &checkParams3D);
+  m.def("matrot3", &matrot3);
+  m.def("matvet3", &matvet3);
+  m.def("matmat3", &matmat3);
+}

--- a/Core/utils.c
+++ b/Core/utils.c
@@ -18,19 +18,19 @@
 #define MAXCHAR 1000
 
 /***********************************************************************************************/
-float checkParams2D(int *params_switch, int ModelSelected, char *ModelParametersFilename)
+float checkParams2D(nb::ndarray< int > params_switch, int ModelSelected, char *ModelParametersFilename)
 {
     /* parameters check which returns 'params_switch' vector with 0/1 values */
-    params_switch[0] = 1; /* parameters file */
-    params_switch[1] = 0; /* model */
-    params_switch[2] = 1; /* components */
-    params_switch[3] = 1; /* time steps (actual value if > 1)*/
-    params_switch[4] = 1; /* model types */
-    params_switch[5] = 1; /* C0 */
-    params_switch[6] = 1; /* x0 */
-    params_switch[7] = 1; /* y0 */
-    params_switch[8] = 1; /* a */
-    params_switch[9] = 1; /* b */
+    params_switch.data()[0] = 1; /* parameters file */
+    params_switch.data()[1] = 0; /* model */
+    params_switch.data()[2] = 1; /* components */
+    params_switch.data()[3] = 1; /* time steps (actual value if > 1)*/
+    params_switch.data()[4] = 1; /* model types */
+    params_switch.data()[5] = 1; /* C0 */
+    params_switch.data()[6] = 1; /* x0 */
+    params_switch.data()[7] = 1; /* y0 */
+    params_switch.data()[8] = 1; /* a */
+    params_switch.data()[9] = 1; /* b */
     
     
     FILE *fp = fopen(ModelParametersFilename, "r"); // read parameters file    
@@ -39,7 +39,7 @@ float checkParams2D(int *params_switch, int ModelSelected, char *ModelParameters
     
     if( fp == NULL ) {
         printf("%s %s\n", "Parameters file does not exist or cannot be read!", ModelParametersFilename);
-        params_switch[0] = 0;
+        params_switch.data()[0] = 0;
         return 0;
     }
     else {
@@ -67,25 +67,25 @@ float checkParams2D(int *params_switch, int ModelSelected, char *ModelParameters
                         if (fgets(str, MAXCHAR, fp) != NULL) sscanf(str, "%15s : %21[^;];", tmpstr1, tmpstr2);
                         else {
                             printf("%s \n", "Unexpected the end of the line (Components) in parameters file");
-                            params_switch[0] = 0;
+                            params_switch.data()[0] = 0;
                             break; }
                         if  (strcmp(tmpstr1,"Components") == 0) Components = atoi(tmpstr2);
                         //printf("%s %i\n", "Components:", Components);
                         if (Components <= 0) {
                             printf("%s %i\n", "Components cannot be negative, the given value is", Components);
-                            params_switch[2] = 0;
+                            params_switch.data()[2] = 0;
                             break; }
                         if (fgets(str, MAXCHAR, fp) != NULL) sscanf(str, "%15s : %21[^;];", tmpstr1, tmpstr2);
                         else {
                             printf("%s \n", "Unexpected the end of the line (TimeSteps) in parameters file");
-                            params_switch[0] = 0;
+                            params_switch.data()[0] = 0;
                             break; }
                         if  (strcmp(tmpstr1,"TimeSteps") == 0) steps = atoi(tmpstr2);
                         if (steps <= 0) {
                             printf("%s %i\n", "TimeSteps cannot be negative, the given value is", steps);
-                            params_switch[3] = 0;
+                            params_switch.data()[3] = 0;
                             break; }
-                        else {params_switch[3] = steps;}
+                        else {params_switch.data()[3] = steps;}
                         //printf("%s %i\n", "TimeSteps:", steps);
                         if (steps == 1) {
                             /**************************************************/
@@ -96,7 +96,7 @@ float checkParams2D(int *params_switch, int ModelSelected, char *ModelParameters
                                 if (fgets(str, MAXCHAR, fp) != NULL) sscanf(str, "%15s : %21s %15s %15s %15s %15s %15s %15[^;];", tmpstr1, tmpstr2, tmpstr3, tmpstr4, tmpstr5, tmpstr6, tmpstr7, tmpstr8);
                                 else {
                                     printf("%s \n", "Unexpected the end of the line (objects loop) in parameters file");
-                                    params_switch[0] = 0;
+                                    params_switch.data()[0] = 0;
                                     break; }
                                 
                                 if  (strcmp(tmpstr1,"Object") == 0) {
@@ -108,32 +108,32 @@ float checkParams2D(int *params_switch, int ModelSelected, char *ModelParameters
                                 }
                                 else {
                                     printf("%s \n", "Cannot find 'Object' string in parameters file");
-                                    params_switch[0] = 0;
+                                    params_switch.data()[0] = 0;
                                     break; }
                                 
                                 if ((strcmp("gaussian",tmpstr2) != 0) && (strcmp("parabola",tmpstr2) != 0) && (strcmp("ellipse",tmpstr2) != 0) && (strcmp("parabola1",tmpstr2) != 0) && (strcmp("cone",tmpstr2) != 0) && (strcmp("rectangle",tmpstr2) != 0) ) {
                                     printf("%s %s\n", "Unknown name of the object, the given name is", tmpstr2);
-                                    params_switch[4] = 0;
+                                    params_switch.data()[4] = 0;
                                     break; }
                                 if (C0 == 0) {
                                     printf("%s %f\n", "C0 should not be equal to zero, the given value is", C0);
-                                    params_switch[5] = 0;
+                                    params_switch.data()[5] = 0;
                                     break; }
                                 if ((x0 < -1) || (x0 > 1)) {
                                     printf("%s %f\n", "x0 (object position) must be in [-1,1] range, the given value is", x0);
-                                    params_switch[6] = 0;
+                                    params_switch.data().data().data().data().data().data().data().data().data()[6] = 0;
                                     break; }
                                 if ((y0 < -1) || (y0 > 1)) {
                                     printf("%s %f\n", "y0 (object position) must be in [-1,1] range, the given value is", y0);
-                                    params_switch[7] = 0;
+                                    params_switch.data()[7] = 0;
                                     break; }
                                 if ((a <= 0) || (a > 2)) {
                                     printf("%s %f\n", "a (object size) must be positive in [0,2] range, the given value is", a);
-                                    params_switch[8] = 0;
+                                    params_switch.data()[8] = 0;
                                     break; }
                                 if ((b <= 0) || (b > 2)) {
                                     printf("%s %f\n", "b (object size) must be positive in [0,2] range, the given value is", b);
-                                    params_switch[9] = 0;
+                                    params_switch.data()[9] = 0;
                                     break; }
                                 // printf("\nObject : %s \nC0 : %f \nx0 : %f \ny0 : %f \na : %f \nb : %f \n", tmpstr2, C0, x0, y0,  a, b);                           
                             }
@@ -150,7 +150,7 @@ float checkParams2D(int *params_switch, int ModelSelected, char *ModelParameters
                                 if (fgets(str, MAXCHAR, fp) != NULL) sscanf(str, "%15s : %15s %15s %15s %15s %15s %15s %15[^;];", tmpstr1, tmpstr2, tmpstr3, tmpstr4, tmpstr5, tmpstr6, tmpstr7, tmpstr8);
                                 else {                                   
                                    printf("%s \n", "Unexpected the end of the line (objects loop) in parameters file");
-                                   params_switch[0] = 0;
+                                   params_switch.data()[0] = 0;
                                    break; }
                                 
                                 if  (strcmp(tmpstr1,"Object") == 0) {
@@ -162,32 +162,32 @@ float checkParams2D(int *params_switch, int ModelSelected, char *ModelParameters
                                 }
                                 else {
                                     printf("%s \n", "Cannot find 'Object' string in parameters file");
-                                    params_switch[0] = 0;
+                                    params_switch.data()[0] = 0;
                                     break; }
                                 
                                 if ((strcmp("gaussian",tmpstr2) != 0) && (strcmp("parabola",tmpstr2) != 0) && (strcmp("ellipse",tmpstr2) != 0) && (strcmp("parabola1",tmpstr2) != 0) && (strcmp("cone",tmpstr2) != 0) && (strcmp("rectangle",tmpstr2) != 0) ) {
                                     printf("%s %s\n", "Unknown name of the object, the given name is", tmpstr2);
-                                    params_switch[4] = 0;
+                                    params_switch.data()[4] = 0;
                                     break; }
                                 if (C0 == 0) {
                                     printf("%s %f\n", "C0 should not be equal to zero, the given value is", C0);
-                                    params_switch[5] = 0;
+                                    params_switch.data()[5] = 0;
                                     break; }
                                 if ((x0 < -1) || (x0 > 1)) {
                                     printf("%s %f\n", "x0 (object position) must be in [-1,1] range, the given value is", x0);
-                                    params_switch[6] = 0;
+                                    params_switch.data()[6] = 0;
                                     break; }
                                 if ((y0 < -1) || (y0 > 1)) {
                                     printf("%s %f\n", "y0 (object position) must be in [-1,1] range, the given value is", y0);
-                                    params_switch[7] = 0;
+                                    params_switch.data()[7] = 0;
                                     break; }
                                 if ((a <= 0) || (a > 2)) {
                                     printf("%s %f\n", "a (object size) must be positive in [0,2] range, the given value is", a);
-                                    params_switch[8] = 0;
+                                    params_switch.data()[8] = 0;
                                     break; }
                                 if ((b <= 0) || (b > 2)) {
                                     printf("%s %f\n", "b (object size) must be positive in [0,2] range, the given value is", b);
-                                    params_switch[9] = 0;
+                                    params_switch.data()[9] = 0;
                                     break; }
                                 printf("\nObject : %s \nC0 : %f \nx0 : %f \ny0 : %f \na : %f \nb : %f \n", tmpstr2, C0, x0, y0, a, b);
                                 
@@ -195,7 +195,7 @@ float checkParams2D(int *params_switch, int ModelSelected, char *ModelParameters
                                 if (fgets(str, MAXCHAR, fp) != NULL) sscanf(str, "%15s : %15s %15s %15s %15s %15s %15[^;];", tmpstr1, tmpstr3, tmpstr4, tmpstr5, tmpstr6, tmpstr7, tmpstr8);
                                 else {
                                     printf("%s \n", "Unexpected the end of the line (Endvar loop) in parameters file");
-                                    params_switch[0] = 0;
+                                    params_switch.data()[0] = 0;
                                     break; }
                                 
                                 if  (strcmp(tmpstr1,"Endvar") == 0) {
@@ -207,46 +207,46 @@ float checkParams2D(int *params_switch, int ModelSelected, char *ModelParameters
                                 }
                                 else {
                                     printf("%s \n", "Cannot find 'Endvar' string in parameters file");
-                                    params_switch[0] = 0;
+                                    params_switch.data()[0] = 0;
                                     break; }
                                 
                                 if (C1 == 0) {
                                     printf("%s %f\n", "Endvar C1 should not be equal to zero, the given value is", C1);
-                                    params_switch[5] = 0;
+                                    params_switch.data()[5] = 0;
                                     break; }
                                 if ((x1 < -1) || (x1 > 1)) {
                                     printf("%s %f\n", "Endvar x1 (object position) must be in [-1,1] range, the given value is", x1);
-                                    params_switch[6] = 0;
+                                    params_switch.data()[6] = 0;
                                     break; }
                                 if ((y1 < -1) || (y1 > 1)) {
                                     printf("%s %f\n", "Endvar y1 (object position) must be in [-1,1] range, the given value is", y1);
-                                    params_switch[7] = 0;
+                                    params_switch.data()[7] = 0;
                                     break; }
                                 if ((a1 <= 0) || (a1 > 2)) {
                                     printf("%s %f\n", "Endvar a1 (object size) must be positive in [0,2] range, the given value is", a1);
-                                    params_switch[8] = 0;
+                                    params_switch.data()[8] = 0;
                                     break; }
                                 if ((b1 <= 0) || (b1 > 2)) {
                                     printf("%s %f\n", "Endvar b1 (object size) must be positive in [0,2] range, the given value is", b1);
-                                    params_switch[9] = 0;
+                                    params_switch.data()[9] = 0;
                                     break; }
                              } /*components loop*/
                         }
-                        params_switch[1] = 1;
+                        params_switch.data()[1] = 1;
                         counter++;
                     } /*model if*/
                 }
             }
         }
     }    
-    if  (params_switch[1] == 0) printf("%s %i\n", "No such model available, the given value is", Model);
+    if  (params_switch.data()[1] == 0) printf("%s %i\n", "No such model available, the given value is", Model);
     fclose(fp);
-    return *params_switch;
+    return *params_switch.data();
 }                
                             
 
 /***********************************************************************************************/
-float checkParams3D(int *params_switch, int ModelSelected, char *ModelParametersFilename)
+float checkParams3D(nb::ndarray<int>  *params_switch, int ModelSelected, char *ModelParametersFilename)
 {
     FILE *fp;
     char str[MAXCHAR];
@@ -263,18 +263,18 @@ float checkParams3D(int *params_switch, int ModelSelected, char *ModelParameters
     char tmpstr11[16];
     char tmpstr12[16];
     
-    params_switch[0] = 1; /* parameters file */
-    params_switch[1] = 0; /* model */
-    params_switch[2] = 1; /* components */
-    params_switch[3] = 1; /* steps (actual value if > 1)*/
-    params_switch[4] = 1; /* model types */
-    params_switch[5] = 1; /* C0 */
-    params_switch[6] = 1; /* x0 */
-    params_switch[7] = 1; /* y0 */
-    params_switch[8] = 1; /* z0 */
-    params_switch[9] = 1; /* a */
-    params_switch[10] = 1; /* b */
-    params_switch[11] = 1; /* c */
+    params_switch.data()[0] = 1; /* parameters file */
+    params_switch.data()[1] = 0; /* model */
+    params_switch.data()[2] = 1; /* components */
+    params_switch.data()[3] = 1; /* steps (actual value if > 1)*/
+    params_switch.data()[4] = 1; /* model types */
+    params_switch.data()[5] = 1; /* C0 */
+    params_switch.data()[6] = 1; /* x0 */
+    params_switch.data()[7] = 1; /* y0 */
+    params_switch.data()[8] = 1; /* z0 */
+    params_switch.data()[9] = 1; /* a */
+    params_switch.data()[10] = 1; /* b */
+    params_switch.data()[11] = 1; /* c */
     
     int Model=0, Components=0, steps = 0, counter=0, ii;
     float C0 = 0.0f, x0 = 0.0f, y0 = 0.0f, z0 = 0.0f, a = 0.0f, b = 0.0f, c = 0.0f;
@@ -282,7 +282,7 @@ float checkParams3D(int *params_switch, int ModelSelected, char *ModelParameters
     fp = fopen(ModelParametersFilename, "r");
     if (fp == NULL){
         printf("Could not open file %s",ModelParametersFilename);
-        params_switch[0] = 0;
+        params_switch.data()[0] = 0;
         return 0;
     }
     else {
@@ -297,26 +297,26 @@ float checkParams3D(int *params_switch, int ModelSelected, char *ModelParameters
                         /* check if we have a right model */
                         if (fgets(str, MAXCHAR, fp) != NULL) sscanf(str, "%15s : %21[^;];", tmpstr1, tmpstr2);
                         else {
-                            params_switch[0] = 0;
+                            params_switch.data()[0] = 0;
                             printf("%s\n", "Unexpected the end of the line (Components) in parameters file");
                             break; }
                         if  (strcmp(tmpstr1,"Components") == 0) Components = atoi(tmpstr2);
                         //printf("%s %i\n", "Components:", Components);
                         if (Components <= 0) {
-                            params_switch[2] = 0; /*checking components*/
+                            params_switch.data()[2] = 0; /*checking components*/
                             printf("%s %i\n", "Components cannot be negative, the given value is", Components);
                             break; }
                         if (fgets(str, MAXCHAR, fp) != NULL) sscanf(str, "%15s : %21[^;];", tmpstr1, tmpstr2);
                         else {
-                            params_switch[0] = 0;
+                            params_switch.data()[0] = 0;
                             printf("%s\n", "Unexpected the end of the line (TimeSteps) in parameters file");
                             break; }
                         if  (strcmp(tmpstr1,"TimeSteps") == 0) steps = atoi(tmpstr2);
                         if (steps <= 0) {
-                            params_switch[3] = 0;
+                            params_switch.data()[3] = 0;
                             printf("%s %i\n", "TimeSteps cannot be negative, the given value is", steps);
                             break; }
-                        else {params_switch[3] = steps;}
+                        else {params_switch.data()[3] = steps;}
                         //printf("%s %i\n", "TimeSteps:", steps);
                         if (steps == 1) {
                             //printf("\n %s %i %s \n", "Stationary 3D model", ModelSelected, " is selected");
@@ -325,7 +325,7 @@ float checkParams3D(int *params_switch, int ModelSelected, char *ModelParameters
                                 
                                 if (fgets(str, MAXCHAR, fp) != NULL) sscanf(str, "%15s : %21s %15s %15s %15s %15s %15s %15s %15s %15s %15s %15[^;];", tmpstr1, tmpstr2, tmpstr3, tmpstr4, tmpstr5, tmpstr6, tmpstr7, tmpstr8, tmpstr9, tmpstr10, tmpstr11, tmpstr12);
                                 else {
-                                    params_switch[0] = 0;
+                                    params_switch.data()[0] = 0;
                                     printf("%s\n", "Unexpected the end of the line (objecta loop) in parameters file");
                                     break; }
                                 
@@ -339,40 +339,40 @@ float checkParams3D(int *params_switch, int ModelSelected, char *ModelParameters
                                     c = (float)atof(tmpstr9); /* b - size object */
                                 }
                                 else {
-                                    params_switch[0] = 0;
+                                    params_switch.data()[0] = 0;
                                     printf("%s\n", "Cannot find 'Object' string in parameters file");
                                     break; }
                                 
                                 if ((strcmp("gaussian",tmpstr2) != 0) && (strcmp("paraboloid",tmpstr2) != 0) && (strcmp("ellipsoid",tmpstr2) != 0) && (strcmp("cone",tmpstr2) != 0) && (strcmp("cuboid",tmpstr2) != 0) && (strcmp("elliptical_cylinder",tmpstr2) != 0) ) {
                                     printf("%s %s\n", "Unknown name of the object, the given name is", tmpstr2);
-                                    params_switch[4] = 0;
+                                    params_switch.data()[4] = 0;
                                     break; }
                                 if (C0 == 0) {
-                                    params_switch[5] = 0;
+                                    params_switch.data()[5] = 0;
                                     printf("%s %f\n", "C0 should not be equal to zero, the given value is", C0);
                                     break; }
                                 if ((x0 < -1) || (x0 > 1)) {
-                                    params_switch[6] = 0;
+                                    params_switch.data()[6] = 0;
                                     printf("%s %f\n", "x0 (object position) must be in [-1,1] range, the given value is", x0);
                                     break; }
                                 if ((y0 < -1) || (y0 > 1)) {
-                                    params_switch[7] = 0;
+                                    params_switch.data()[7] = 0;
                                     printf("%s %f\n", "y0 (object position) must be in [-1,1] range, the given value is", y0);
                                     break; }
                                 if ((z0 < -1) || (z0 > 1)) {
-                                    params_switch[8] = 0;
+                                    params_switch.data()[8] = 0;
                                     printf("%s %f\n", "z0 (object position) must be in [-1,1] range, the given value is", z0);
                                     break; }
                                 if ((a <= 0) || (a > 2)) {
-                                    params_switch[9] = 0;
+                                    params_switch.data()[9] = 0;
                                     printf("%s %f\n", "a (object size) must be positive in [0,2] range, the given value is", a);
                                     break; }
                                 if ((b <= 0) || (b > 2)) {
-                                    params_switch[10] = 0;
+                                    params_switch.data()[10] = 0;
                                     printf("%s %f\n", "b (object size) must be positive in [0,2] range, the given value is", b);
                                     break; }
                                 if ((c <= 0) || (c > 2)) {
-                                    params_switch[11] = 0;
+                                    params_switch.data()[11] = 0;
                                     printf("%s %f\n", "c (object size) must be positive in [0,2] range, the given value is", c);
                                     break; }
                                 //printf("\nObject : %s \nC0 : %f \nx0 : %f \ny0 : %f \nz0 : %f \na : %f \nb : %f \nc : %f \n", tmpstr2, C0, x0, y0, z0, a, b, c);
@@ -385,7 +385,7 @@ float checkParams3D(int *params_switch, int ModelSelected, char *ModelParameters
                                 
                                 if (fgets(str, MAXCHAR, fp) != NULL) sscanf(str, "%15s : %21s %15s %15s %15s %15s %15s %15s %15s %15s %15s %15[^;];", tmpstr1, tmpstr2, tmpstr3, tmpstr4, tmpstr5, tmpstr6, tmpstr7, tmpstr8, tmpstr9, tmpstr10, tmpstr11, tmpstr12);
                                 else {
-                                    params_switch[0] = 0;
+                                    params_switch.data()[0] = 0;
                                     printf("%s\n", "Unexpected the end of the line (objecta loop) in parameters file");
                                     break; }
                                 
@@ -399,40 +399,40 @@ float checkParams3D(int *params_switch, int ModelSelected, char *ModelParameters
                                     c = (float)atof(tmpstr9); /* b - size object */
                                 }
                                 else {
-                                    params_switch[0] = 0;
+                                    params_switch.data()[0] = 0;
                                     printf("%s\n", "Cannot find 'Object' string in parameters file");
                                     break; }
                                 
                                 if ((strcmp("gaussian",tmpstr2) != 0) && (strcmp("paraboloid",tmpstr2) != 0) && (strcmp("ellipsoid",tmpstr2) != 0) && (strcmp("cone",tmpstr2) != 0) && (strcmp("cuboid",tmpstr2) != 0) && (strcmp("elliptical_cylinder",tmpstr2) != 0) ) {
                                     printf("%s %s\n", "Unknown name of the object, the given name is", tmpstr2);
-                                    params_switch[4] = 0;
+                                    params_switch.data()[4] = 0;
                                     break; }
                                 if (C0 == 0) {
-                                    params_switch[5] = 0;
+                                    .data()params_switch[5] = 0;
                                     printf("%s %f\n", "C0 should not be equal to zero, the given value is", C0);
                                     break; }
                                 if ((x0 < -1) || (x0 > 1)) {
-                                    params_switch[6] = 0;
+                                    .data()params_switch.data()[6] = 0;
                                     printf("%s %f\n", "x0 (object position) must be in [-1,1] range, the given value is", x0);
                                     break; }
                                 if ((y0 < -1) || (y0 > 1)) {
-                                    params_switch[7] = 0;
+                                    params_switch.data()[7] = 0;
                                     printf("%s %f\n", "y0 (object position) must be in [-1,1] range, the given value is", y0);
                                     break; }
                                 if ((z0 < -1) || (z0 > 1)) {
-                                    params_switch[8] = 0;
+                                    params_switch.data()[8] = 0;
                                     printf("%s %f\n", "z0 (object position) must be in [-1,1] range, the given value is", z0);
                                     break; }
                                 if ((a <= 0) || (a > 2)) {
-                                    params_switch[9] = 0;
+                                    params_switch.data()[9] = 0;
                                     printf("%s %f\n", "a (object size) must be positive in [0,2] range, the given value is", a);
                                     break; }
                                 if ((b <= 0) || (b > 2)) {
-                                    params_switch[10] = 0;
+                                    params_switch.data()[10] = 0;
                                     printf("%s %f\n", "b (object size) must be positive in [0,2] range, the given value is", b);
                                     break; }
                                 if ((c <= 0) || (c > 2)) {
-                                    params_switch[11] = 0;
+                                    params_switch.data()[11] = 0;
                                     printf("%s %f\n", "c (object size) must be positive in [0,2] range, the given value is", c);
                                     break; }
                                 // printf("\nObject : %s \nC0 : %f \nx0 : %f \ny0 : %f \nz0 : %f \na : %f \nb : %f \n", tmpstr2, C0, x0, y0, z0, a, b, c);
@@ -440,7 +440,7 @@ float checkParams3D(int *params_switch, int ModelSelected, char *ModelParameters
                                 /* check Endvar relatedparameters */
                                 if (fgets(str, MAXCHAR, fp) != NULL) sscanf(str, "%15s : %15s %15s %15s %15s %15s %15s %15s %15s %15s %15[^;];", tmpstr1, tmpstr3, tmpstr4, tmpstr5, tmpstr6, tmpstr7, tmpstr8, tmpstr9, tmpstr10, tmpstr11, tmpstr12);
                                 else {
-                                    params_switch[0] = 0;
+                                    params_switch.data()[0] = 0;
                                     printf("%s\n", "Unexpected the end of the line (Endvar loop) in parameters file");
                                     break; }
                                 
@@ -454,90 +454,90 @@ float checkParams3D(int *params_switch, int ModelSelected, char *ModelParameters
                                     c = (float)atof(tmpstr9); /* b - size object */
                                 }
                                 else {
-                                    params_switch[0] = 0;
+                                    params_switch.data()[0] = 0;
                                     printf("%s\n", "Cannot find 'Endvar' string in parameters file");
                                     break; }
                                 
                                 if (C0 == 0) {
-                                    params_switch[5] = 0;
+                                    params_switch.data()[5] = 0;
                                     printf("%s %f\n", "Endvar C0 should not be equal to zero, the given value is", C0);
                                     break; }
                                 if ((x0 < -1) || (x0 > 1)) {
-                                    params_switch[6] = 0;
+                                    params_switch.data()[6] = 0;
                                     printf("%s %f\n", "Endvar x0 (object position) must be in [-1,1] range, the given value is", x0);
                                     break; }
                                 if ((y0 < -1) || (y0 > 1)) {
-                                    params_switch[7] = 0;
+                                    params_switch.data()[7] = 0;
                                     printf("%s %f\n", "Endvar y0 (object position) must be in [-1,1] range, the given value is", y0);
                                     break; }
                                 if ((z0 < -1) || (z0 > 1)) {
-                                    params_switch[8] = 0;
+                                    params_switch.data()[8] = 0;
                                     printf("%s %f\n", "Endvar z0 (object position) must be in [-1,1] range, the given value is", z0);
                                     break; }
                                 if ((a <= 0) || (a > 2)) {
-                                    params_switch[9] = 0;
+                                    params_switch.data()[9] = 0;
                                     printf("%s %f\n", "Endvar a (object size) must be positive in [0,2] range, the given value is", a);
                                     break; }
                                 if ((b <= 0) || (b > 2)) {
-                                    params_switch[10] = 0;
+                                    params_switch.data()[10] = 0;
                                     printf("%s %f\n", "Endvar b (object size) must be positive in [0,2] range, the given value is", b);
                                     break; }
                                 if ((c <= 0) || (c > 2)) {
-                                    params_switch[11] = 0;
+                                    params_switch.data()[11] = 0;
                                     printf("%s %f\n", "Endvar c (object size) must be positive in [0,2] range, the given value is", c);
                                     break; }
                                //printf("\nObject : %s \nC0 : %f \nx0 : %f \ny0 : %f \nz0 : %f \na : %f \nb : %f \nc : %f \n", tmpstr2, C0, x0, y0, z0, a, b, c);
                             } /*components loop*/
                         }
-                        params_switch[1] = 1;
+                        params_switch.data()[1] = 1;
                         counter++;
                     }
                 }
             }
         }       
     }
-    if  (params_switch[1] == 0) printf("%s %i\n", "No such model available, the given value is", Model);
+    if  (params_switch.data()[1] == 0) printf("%s %i\n", "No such model available, the given value is", Model);
     fclose(fp);
-    return *params_switch;
+    return *params_switch.data();
 }
 
 /***********************************************************************************************/
 /* rotation matrix */
-float matrot3(float Ad[3][3], float psi1, float psi2, float psi3)
+float matrot3(nb::ndarray<float, nb::shape<3, 3> > Ad, float psi1, float psi2, float psi3)
 {
-    Ad[0][0]=cosf(psi1)*cosf(psi2)*cosf(psi3)-sinf(psi1)*sinf(psi3);
-    Ad[0][1]=sinf(psi1)*cosf(psi2)*cosf(psi3)+cosf(psi1)*sinf(psi3);
-    Ad[0][2]=-sinf(psi2)*cosf(psi3);
-    Ad[1][0]=-cosf(psi1)*cosf(psi2)*sinf(psi3)-sinf(psi1)*cosf(psi3);
-    Ad[1][1]=-sinf(psi1)*cosf(psi2)*sinf(psi3)+cosf(psi1)*cosf(psi3);
-    Ad[1][2]=sinf(psi2)*sinf(psi3);
-    Ad[2][0]=cosf(psi1)*sinf(psi2);
-    Ad[2][1]=sinf(psi1)*sinf(psi2);
-    Ad[2][2]=cosf(psi2);
+    Ad.data()[0][0]=cosf(psi1)*cosf(psi2)*cosf(psi3)-sinf(psi1)*sinf(psi3);
+    Ad.data()[0][1]=sinf(psi1)*cosf(psi2)*cosf(psi3)+cosf(psi1)*sinf(psi3);
+    Ad.data()[0][2]=-sinf(psi2)*cosf(psi3);
+    Ad.data()[1][0]=-cosf(psi1)*cosf(psi2)*sinf(psi3)-sinf(psi1)*cosf(psi3);
+    Ad.data()[1][1]=-sinf(psi1)*cosf(psi2)*sinf(psi3)+cosf(psi1)*cosf(psi3);
+    Ad.data()[1][2]=sinf(psi2)*sinf(psi3);
+    Ad.data()[2][0]=cosf(psi1)*sinf(psi2);
+    Ad.data()[2][1]=sinf(psi1)*sinf(psi2);
+    Ad.data()[2][2]=cosf(psi2);
     return 1;
 }
 
 /*matrix-vector multiplication*/
-float matvet3(float Ad[3][3], float V1[3], float V2[3])
+float matvet3(nb::ndarray< float, nb::shape<3, 3> > Ad, nb::ndarray<float, nb::shape<3>> nb::ndarray< float, nb::shape<3>> V1, nb::ndarray<float, nb::shape<3>> V2)
 {
     int l, m;        
     for(l=0; l<3; l++) {
-        V2[l] = 0.0f;
+        V2.data()[l] = 0.0f;
         for(m=0; m<3; m++) {
-            V2[l] += Ad[l][m]*V1[m];
+            V2.data()[l] += Ad.data()[l][m]*V1.data()[m];
         }}
     return 1;
 }
 
 /*matrix-matrix multiplication*/
-float matmat3(float Am[3][3], float Bm[3][3], float Cm[3][3])
+float matmat3(nb::ndarray<float, nb::shape<3, 3>> Am, nb::ndarray<float, nb::shape<3, 3>> Bm, nb::ndarray< float, nb::shape<3, 3>> Cm)
 {
     int i, j, k;
     for(i=0; i<3; i++) {
         for(j=0; j<3; j++) {
-             Cm[i][j]=0.0f;
+             Cm.data()[i][j]=0.0f;
              for(k=0; k<3; k++) {
-                 Cm[i][j] += Am[i][k]*Bm[k][j];
+                 Cm.data()[i][j] += Am.data()[i][k]*Bm.data()[k][j];
              }
         }}
     return 1;  

--- a/Core/utils.h
+++ b/Core/utils.h
@@ -18,14 +18,8 @@ limitations under the License.
 #include "omp.h"
 #include "CCPiDefines.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-CCPI_EXPORT float checkParams2D(int *params_switch, int ModelSelected, char *ModelParametersFilename);
-CCPI_EXPORT float checkParams3D(int *params_switch, int ModelSelected, char *ModelParametersFilename);
-CCPI_EXPORT float matrot3(float Ad[3][3], float psi1, float psi2, float psi3);
-CCPI_EXPORT float matvet3(float Ad[3][3], float V1[3], float V2[3]);
-CCPI_EXPORT float matmat3(float Am[3][3], float Bm[3][3], float Cm[3][3]);
-#ifdef __cplusplus
-}
-#endif
+float checkParams2D(nb::ndarray<int> params_switch, int ModelSelected, char *ModelParametersFilename);
+float checkParams3D(nb::ndarray<int> params_switch, int ModelSelected, char *ModelParametersFilename);
+float matrot3(nb::ndarray<float, nb::shape<3, 3>> Ad, float psi1, float psi2, float psi3);
+float matvet3(nb::ndarray<float, nb::shape<3, 3>> Ad, nb::ndarray<float, nb::shape<3>> V1, nb::ndarray<float, nb::shape<3>> V2);
+float matmat3(nb::ndarray<float, nb::shape<3, 3>> Am, nb::ndarray<float, nb::shape<3, 3>> Bm, nb::ndarray<float, nb::shape<3, 3>> Cm);


### PR DESCRIPTION
This is an in-progress switch to using `scikit-build-core` for the build system. 
As of now, I've just added (untested) bindings in cpp for nanobind. I've done this by switching numerical pointers to ndarray types, and then just calling `.data()` on those new types to get the underlying pointers to the arrays. I'm sure that this can be simplified in the c code, but this is just meant to be as low effort of a switch as possible. 
Next would be to fix the python interface to use these bindings correctly, and to  set up `scikit-build-core` as a build dependency. 