### PR TITLE
setup conda correctly

### DIFF
--- a/.github/workflows/libtomophantom_conda_upload.yml
+++ b/.github/workflows/libtomophantom_conda_upload.yml
@@ -4,10 +4,15 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches: [master]
 
 jobs:
   build-linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     defaults:
       run:
@@ -17,24 +22,32 @@ jobs:
       - name: Checkout repository code
         uses: actions/checkout@v5
 
-      # setup Python 3.12
-      - name: Setup Python 3.12
-        uses: actions/setup-python@v5
+      # setup conda
+      - name: setup conda
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
+        
 
       - name: Install dependencies with Conda
         run: |
-          $CONDA/bin/conda install -c conda-forge conda-build anaconda-client
+          $CONDA/bin/conda install -c conda-forge conda-build anaconda-client python=${{ matrix.python-version }}
           $CONDA/bin/conda install --solver=classic conda-forge::conda-libmamba-solver conda-forge::libmamba conda-forge::libmambapy conda-forge::libarchive
           $CONDA/bin/conda install -c conda-forge cmake
           $CONDA/bin/conda update conda
           $CONDA/bin/conda update conda-build
           $CONDA/bin/conda list
+      
 
       - name: Upload the tested package to conda cloud
         run: |
-          chmod +x ./.scripts/conda_upload_lib.sh
-          ./.scripts/conda_upload_lib.sh
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            echo "Pull request detected, skipping conda upload."
+            chmod +x ./.scripts/conda_upload_lib.sh
+            ./.scripts/conda_upload_lib.sh -p
+          else
+            chmod +x ./.scripts/conda_upload_lib.sh
+            ./.scripts/conda_upload_lib.sh
+          fi
         env:
           ANACONDA_API_TOKEN: ${{ secrets.HTTOMO_TOKEN_27 }}

--- a/.github/workflows/tomophantom_conda_upload.yml
+++ b/.github/workflows/tomophantom_conda_upload.yml
@@ -4,10 +4,15 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches: [master]
 
 jobs:
   build-linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     defaults:
       run:
@@ -17,22 +22,28 @@ jobs:
       - name: Checkout repository code
         uses: actions/checkout@v5
 
-      # setup Python 3.12
-      - name: Setup Python 3.12
-        uses: actions/setup-python@v5
+      # setup conda
+      - name: setup conda
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies with Conda
         run: |
-          $CONDA/bin/conda install -c conda-forge conda-build anaconda-client          
+          $CONDA/bin/conda install -c conda-forge conda-build anaconda-client python=${{ matrix.python-version }}
           $CONDA/bin/conda update conda
           $CONDA/bin/conda update conda-build
           $CONDA/bin/conda list
 
       - name: Upload the tested package to conda cloud
         run: |
-          chmod +x ./.scripts/conda_upload.sh
-          ./.scripts/conda_upload.sh
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            echo "Pull request detected, skipping conda upload."
+            chmod +x ./.scripts/conda_upload_lib.sh
+            ./.scripts/conda_upload.sh -p
+          else
+            chmod +x ./.scripts/conda_upload_lib.sh
+            ./.scripts/conda_upload.sh
+          fi
         env:
           ANACONDA_API_TOKEN: ${{ secrets.HTTOMO_TOKEN_27 }}          

--- a/.scripts/conda_upload.sh
+++ b/.scripts/conda_upload.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+is_pr=0
+while getopts :p option; do
+  case "${option}" in
+  p) is_pr=1 ;; # pull request
+  *) ;;
+  esac
+done
+
 PKG_NAME=tomophantom
 USER=httomo-team
 OS=noarch
@@ -8,12 +16,20 @@ mkdir ~/conda-bld
 conda config --set anaconda_upload no
 export CONDA_BLD_PATH=~/conda-bld
 
-export CIL_VERSION=3.0.2
+export CIL_VERSION=3.0.3
 $CONDA/bin/conda build conda-recipe . -c httomo
 
 # upload packages to conda
-find $CONDA_BLD_PATH/$OS -name *.conda | while read file
-do
-    echo $file
-    $CONDA/bin/anaconda -v --show-traceback -t $ANACONDA_API_TOKEN upload $file --force
-done
+
+if [ $is_pr -eq 1 ]; then
+    echo "Pull request detected, skipping conda upload."
+    exit 0
+else
+    # upload packages to conda
+    find $CONDA_BLD_PATH/$OS -name *.conda | while read file
+    do
+        echo $file
+        $CONDA/bin/anaconda -v --show-traceback -t $ANACONDA_API_TOKEN upload $file --force
+    done
+
+fi

--- a/.scripts/conda_upload_lib.sh
+++ b/.scripts/conda_upload_lib.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+is_pr=0
+while getopts :p option; do
+  case "${option}" in
+  p) is_pr=1 ;; # pull request
+  *) ;;
+  esac
+done
 
 PKG_NAME=libtomophantom
 USER=httomo-team
@@ -8,12 +15,18 @@ mkdir ~/conda-bld
 conda config --set anaconda_upload no
 export CONDA_BLD_PATH=~/conda-bld
 
-export CIL_VERSION=3.0.2
+export CIL_VERSION=3.0.3
 $CONDA/bin/conda build conda-recipe_library . -c httomo
 
-# upload packages to conda
-find $CONDA_BLD_PATH/$OS -name *.conda | while read file
-do
-    echo $file
-    $CONDA/bin/anaconda -v --show-traceback -t $ANACONDA_API_TOKEN upload $file --force
-done
+if [ $is_pr -eq 1 ]; then
+    echo "Pull request detected, skipping conda upload."
+    exit 0
+else
+    # upload packages to conda
+    find $CONDA_BLD_PATH/$OS -name *.conda | while read file
+    do
+        echo $file
+        $CONDA/bin/anaconda -v --show-traceback -t $ANACONDA_API_TOKEN upload $file --force
+    done
+
+fi


### PR DESCRIPTION
Setup conda with the correct python version on the GHA. 

- closes #129 
- adds a GHA workflow to test the conda package on Pull Requests which does not upload to the `httomo` channel
- the doc github action fails without any reference to the changes here.