### PR TITLE
Fix singular-angle handling for analytical rectangle/cuboid projections

### DIFF
--- a/Core/TomoP2DModelSino_core.c
+++ b/Core/TomoP2DModelSino_core.c
@@ -16,6 +16,7 @@
 
 #define M_PI 3.14159265358979323846
 #define EPS 0.000000001
+#define DIV_EPS 0.000001
 #define MAXCHAR 1000
 
 /* Function to create 2D analytical sinograms (parallel beam geometry) to from models using Phantom2DLibrary.dat
@@ -227,20 +228,23 @@ float TomoP2DObjectSino_core(float *A, int N, int P, float *Th, int AngTot, int 
                 SF = sinf(FI);
                 P0 = fabs(p-XSYC);
                 
-                SS = xwid/CF*C0;
-                
-                if (fabs(CF) <= (float)EPS) {
+                if (fabs(CF) <= DIV_EPS) {
                     SS = ywid*C0;
                     if ((P0 - A2) > (float)EPS) {
                         SS=0.0f;
                     }
+                    A[tt*AngTot*P+ j*AngTot+i] += (N/2.0f)*SS;
+                    continue;
                 }
-                if (fabs(SF) <= (float)EPS) {
+                if (fabs(SF) <= DIV_EPS) {
                     SS = xwid*C0;
                     if ((P0 - B2) > (float)EPS) {
                         SS=0.0f;
                     }
+                    A[tt*AngTot*P+ j*AngTot+i] += (N/2.0f)*SS;
+                    continue;
                 }
+                SS = xwid/CF*C0;
                 TF = SF/CF;
                 PC = P0/CF;
                 QP = B2+A2*TF;

--- a/Core/TomoP3DModelSino_core.c
+++ b/Core/TomoP3DModelSino_core.c
@@ -18,6 +18,7 @@
 #define M_PI 3.14159265358979323846
 #define M_PI2 1.57079632679
 #define EPS 0.000000001
+#define DIV_EPS 0.000001
 #define MAXCHAR 1000
 
 /* Function to create 3D analytical projection data (parallel beam geometry) for 3D models
@@ -303,17 +304,20 @@ float TomoP3DObjectSino_core(float *A, long Horiz_det, long Vert_det, long Z1, l
                                     SF = sinf(FI);
                                     P0 = fabs(p-XSYC);
                                     
-                                    SS = xwid/CF*C0;
-                                    
-                                    if (fabs(CF) <= (float)EPS) {
+                                    if (fabs(CF) <= DIV_EPS) {
                                         SS = ywid*C0;
                                         if ((P0 - A2) > (float)EPS) SS=0.0f;
+                                        A[index] += (N/2.0f)*SS;
+                                        continue;
                                     }
-                                    if (fabs(SF) <= (float)EPS) {
+                                    if (fabs(SF) <= DIV_EPS) {
                                         SS = xwid*C0;
                                         if ((P0 - B2) > (float)EPS) SS=0.0f;
+                                        A[index] += (N/2.0f)*SS;
+                                        continue;
                                     }
                                     
+                                    SS = xwid/CF*C0;
                                     TF = SF/CF;
                                     PC = P0/CF;
                                     QP = B2+A2*TF;


### PR DESCRIPTION
# Fix singular-angle handling for analytical rectangle/cuboid projections

Fixes [#131](https://github.com/dkazanc/TomoPhantom/issues/131).

## Summary

For models that include `rectangle` components in 2D or `cuboid` components in 3D, the analytical projector could return invalid values near singular angles.
The root cause was that the near-singular cases were detected, but the code could still fall through into the generic formula and divide by `CF` or `SF`.

This PR handles those singular branches first and exits them immediately, so the generic branch is skipped when `CF` or `SF` is near zero.

## Affected code

- `Core/TomoP2DModelSino_core.c`
- `Core/TomoP3DModelSino_core.c`

## Changes in this PR

- handle `fabs(CF) <= DIV_EPS` before any division by `CF`
- handle `fabs(SF) <= DIV_EPS` before any division by `SF`
- `continue` after each singular branch so the generic formula is not evaluated for those cases
- apply the same control-flow fix to both the 2D rectangle branch and the 3D cuboid branch

## Reproducer

Using the public Python API, the original issue can be reproduced with a built-in 2D model containing rectangle components, e.g. model `9` from `Phantom2DLibrary.dat`.

```python
import os
import numpy as np
import tomophantom
from tomophantom import TomoP2D

model = 9
N_size = 512
P = 512
angles = np.linspace(0.0, 180.0 - 180.0 / 512, 512, dtype="float32")

path = os.path.dirname(tomophantom.__file__)
path_library2D = os.path.join(path, "phantomlib", "Phantom2DLibrary.dat")

sino = TomoP2D.ModelSino(model, N_size, P, angles, path_library2D)

print("min =", np.min(sino))
print("argmin =", np.unravel_index(np.argmin(sino), sino.shape))
print("max =", np.max(sino))
print("argmax =", np.unravel_index(np.argmax(sino), sino.shape))
print("sino[255, 0] =", sino[255, 0])
```

Example output before this patch:

```text
min = -2928298800.0
argmin = (255, 0)
max = 240.64148
argmax = (256, 254)
sino[255, 0] = -2928298800.0
```

Expected behavior:

- no huge negative outlier near singular angles
- the minimum should stay near `0`

## Root cause

In the rectangle/cuboid branch, the code checked for near-singular cases:

- `fabs(CF) <= DIV_EPS`
- `fabs(SF) <= DIV_EPS`

but could still proceed to compute divisions such as:

- `SS = xwid / CF * C0`
- `TF = SF / CF`
- `PC = P0 / CF`

and later also terms divided by `SF`.

## Scope

This PR is limited to the singular-angle fallthrough bug reported in issue #131.
