### PR TITLE
conda: fix glibc compatibility

### DIFF
--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -7,14 +7,16 @@ on:
     branches: [master]
 jobs:
   build:
-    runs-on: ${{ matrix.os == 'macos-intel' && 'macos' || matrix.os }}-${{ matrix.os == 'macos-intel' && '15-intel' || 'latest' }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu, windows, macos, macos-intel]
+        # use oldest ubuntu/macos images for max glibc compat:
+        # https://stackoverflow.com/q/70019660
+        os: [ubuntu-22.04, windows-latest, macos-14, macos-15-intel]
     steps:
       - uses: actions/checkout@v6
         with: {fetch-depth: 0}
-      - if: matrix.os == 'windows'
+      - if: startsWith(matrix.os, 'windows')
         uses: ilammy/msvc-dev-cmd@v1
       - uses: prefix-dev/rattler-build-action@v0.2.37
         with:

--- a/tomophantom/ctypes/__init__.py
+++ b/tomophantom/ctypes/__init__.py
@@ -33,23 +33,10 @@ def c_shared_lib(lib_name, error=True):
         try:
             # No error if mylib_path is None; error if library name wrong
             return load_dll(mylib_path)
-        except OSError:
-            pass
-
-    explanation = (
-        "TomoPhantom links to compiled components which are installed separately"
-        " and loaded using ctypes.util.find_library()."
-    )
-    if error:
-        raise ModuleNotFoundError(
-            explanation + f" A required library, {lib_name}, was not found."
-        )
-    warnings.warn(
-        explanation + "Some functionality is unavailable because an optional shared"
-        f" library, {lib_name}, is missing.",
-        ImportWarning,
-    )
-    return None
+        except Exception as exc:
+            if error:
+                raise ModuleNotFoundError(lib_name) from exc
+    warnings.warn(lib_name, ImportWarning, stacklevel=2)
 
 
 from tomophantom.TomoP2D import *


### PR DESCRIPTION
- [x] don't hide import error message
- [x] build against older glibc for compatibility

```py
>>> ctypes.cdll.LoadLibrary(ctypes.util.find_library("tomophantom"))
Traceback (most recent call last):
  File "lib/python3.13/ctypes/__init__.py", line 482, in LoadLibrary
    return self._dlltype(name)
           ~~~~~~~~~~~~~^^^^^^
  File "lib/python3.13/ctypes/__init__.py", line 361, in __init__
    self._handle = self._load_library(name, mode, handle, winmode)
                   ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "lib/python3.13/ctypes/__init__.py", line 403, in _load_library
    return _dlopen(name, mode)
OSError: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by lib/libtomophantom.so)
```

Underlying cause & solution: https://stackoverflow.com/questions/70019660/including-glibc-in-a-conda-package

Was also hard to debug because of misleading wrapped import errors, vis. https://github.com/SyneRBI/SIRF-SuperBuild/actions/runs/25730697942/job/75554903970?pr=994#step:13:4563

```py
>>> import tomophantom
Traceback (most recent call last):
  File "/usr/share/miniconda/lib/python3.13/site-packages/tomophantom/__init__.py", line 3, in <module>
    from tomophantom.TomoP2D import *
  File "/usr/share/miniconda/lib/python3.13/site-packages/tomophantom/TomoP2D.py", line 21, in <module>
    import tomophantom.ctypes.external as external
  File "/usr/share/miniconda/lib/python3.13/site-packages/tomophantom/ctypes/external.py", line 36, in <module>
    LIB_TOMOPHANTOM = c_shared_lib("tomophantom")
  File "/usr/share/miniconda/lib/python3.13/site-packages/tomophantom/ctypes/__init__.py", line 44, in c_shared_lib
    raise ModuleNotFoundError(
        explanation + f" A required library, {lib_name}, was not found."
    )
ModuleNotFoundError: TomoPhantom links to compiled components which are installed separately and loaded using ctypes.util.find_library(). A required library, tomophantom, was not found.
```