### PR TITLE
CI: fix conda upload

### DIFF
--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -27,7 +27,7 @@ jobs:
         name: conda upload -c httomo
         run: |
           rattler-build upload anaconda -o httomo -f ./output/*/lib*.conda     # library
-          if test ${{ matrix.os }} = ubuntu ; then
+          if [[ ${{ matrix.os }} =~ ubuntu* ]] ; then
             rattler-build upload anaconda -o httomo -f ./output/noarch/*.conda # noarch: python
           fi
         shell: bash


### PR DESCRIPTION
Follow-up to #139 (`libtomophantom` was uploaded, but `tomophantom` was not).

/CC @dkazanc

I'd suggest merging this PR then force-pushing the tag

```sh
git tag -f v3.1.4
git push --tags -f
```